### PR TITLE
Add remote Letta API transcript adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ and is empty when the transcript required no recoverable cleanup.
 | `claude-code` | Native Claude Code JSONL | `claude-code` |
 | `codex` | Native Codex rollout JSONL | `codex` |
 | `letta` | Cloud/API message array or local conversation JSONL (legacy and v3) | `letta` |
+| `letta-api` | Remote Letta conversation or legacy agent message history | `letta` |
 | `openhands` | JSON event array or an events-API `{ "items": [...] }` envelope | `openhands` |
 | `deepagents` | User-supplied Python LangGraph `SqliteSaver` database plus `threadId` | `deepagents` |
 
@@ -126,7 +127,25 @@ local conversation files from `lc-local-backend/conversations/*/messages.jsonl`:
 legacy headerless message rows and version 3 session-entry JSONL. Compaction
 entries are excluded because they summarize existing conversation context.
 The separate `~/.letta/transcripts` tree contains reflection artifacts and is
-not a supported native input. OpenHands inputs are serialized exports; when a
+not a supported native input. To fetch the corresponding server-side history,
+use the asynchronous `letta-api` adapter with exactly one remote identifier:
+
+```ts
+import { normalizeLettaApi } from "@letta-ai/trajectory";
+
+const result = await normalizeLettaApi({
+  source: "letta-api",
+  conversationId: "conv-...",
+  // agentId: "agent-...", // legacy default-conversation endpoint
+  // apiKey: "...",       // defaults to LETTA_API_KEY
+  // baseUrl: "...",      // defaults to LETTA_BASE_URL, then api.letta.com
+});
+```
+
+The adapter follows cursor pagination and feeds the complete API message array
+through the same Letta decoder used for local transcripts, so both paths have
+identical normalization semantics and normalized `meta.source: "letta"`.
+OpenHands inputs are serialized exports; when a
 native store uses individual event files, assembling the event array remains
 the caller's responsibility.
 

--- a/python/src/trajectory/__init__.py
+++ b/python/src/trajectory/__init__.py
@@ -1,15 +1,22 @@
 """Normalize native agent transcripts using the canonical trajectory runtime."""
 
-from ._client import normalize_checkpoint, normalize_many, normalize_transcript
+from ._client import (
+    normalize_checkpoint,
+    normalize_letta_api,
+    normalize_many,
+    normalize_transcript,
+)
 from ._errors import NodeUnavailableError, NormalizationError, TrajectoryRuntimeError
 from ._types import (
     AssistantMessageRecord,
     AssistantToolCallRecord,
     AnyTrajectorySource,
+    ApiTrajectorySource,
     CheckpointTrajectorySource,
     DeepAgentsCheckpointInput,
     DeepAgentsCheckpointLocation,
     Diagnostic,
+    LettaApiInput,
     DiagnosticCode,
     MetaRecord,
     NormalizationBounds,
@@ -32,11 +39,13 @@ __all__ = [
     "AssistantMessageRecord",
     "AssistantToolCallRecord",
     "AnyTrajectorySource",
+    "ApiTrajectorySource",
     "CheckpointTrajectorySource",
     "DeepAgentsCheckpointInput",
     "DeepAgentsCheckpointLocation",
     "Diagnostic",
     "DiagnosticCode",
+    "LettaApiInput",
     "MetaRecord",
     "NodeUnavailableError",
     "NormalizationBounds",
@@ -57,6 +66,7 @@ __all__ = [
     "UserRecord",
     "normalize_many",
     "normalize_checkpoint",
+    "normalize_letta_api",
     "normalize_transcript",
 ]
 

--- a/python/src/trajectory/_client.py
+++ b/python/src/trajectory/_client.py
@@ -14,6 +14,7 @@ from typing import cast
 
 from ._errors import NodeUnavailableError, NormalizationError, TrajectoryRuntimeError
 from ._types import (
+    LettaApiInput,
     NormalizationBounds,
     NormalizationErrorCode,
     NormalizeInput,
@@ -36,6 +37,30 @@ def normalize_transcript(
     """Normalize one native transcript."""
 
     request: NormalizeInput = {"source": source, "transcript": transcript}
+    if bounds is not None:
+        request["bounds"] = bounds
+    return normalize_many([request])[0]
+
+
+def normalize_letta_api(
+    *,
+    conversation_id: str | None = None,
+    agent_id: str | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    bounds: NormalizationBounds | None = None,
+) -> NormalizeResult:
+    """Fetch and normalize a complete remote Letta message history."""
+
+    request: LettaApiInput = {"source": "letta-api"}
+    if conversation_id is not None:
+        request["conversationId"] = conversation_id
+    if agent_id is not None:
+        request["agentId"] = agent_id
+    if api_key is not None:
+        request["apiKey"] = api_key
+    if base_url is not None:
+        request["baseUrl"] = base_url
     if bounds is not None:
         request["bounds"] = bounds
     return normalize_many([request])[0]

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -4,8 +4,9 @@ from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal["claude-code", "codex", "letta", "openhands"]
 CheckpointTrajectorySource = Literal["deepagents"]
+ApiTrajectorySource = Literal["letta-api"]
 AnyTrajectorySource = Literal[
-    "claude-code", "codex", "letta", "openhands", "deepagents"
+    "claude-code", "codex", "letta", "openhands", "deepagents", "letta-api"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 DiagnosticCode = Literal[
@@ -36,6 +37,9 @@ NormalizationErrorCode = Literal[
     "checkpoint_not_found",
     "checkpoint_messages_missing",
     "invalid_checkpoint_state",
+    "letta_api_auth_missing",
+    "letta_api_request_failed",
+    "letta_api_response_invalid",
     "missing_user_records",
     "missing_assistant_records",
     "invalid_normalized_transcript",
@@ -81,7 +85,19 @@ class DeepAgentsCheckpointInput(_NormalizeInputOptional):
     checkpoint: DeepAgentsCheckpointLocation
 
 
-NormalizeRequest = Union[NormalizeInput, DeepAgentsCheckpointInput]
+class _LettaApiInputOptional(TypedDict, total=False):
+    conversationId: str
+    agentId: str
+    apiKey: str
+    baseUrl: str
+    bounds: NormalizationBounds
+
+
+class LettaApiInput(_LettaApiInputOptional):
+    source: Literal["letta-api"]
+
+
+NormalizeRequest = Union[NormalizeInput, DeepAgentsCheckpointInput, LettaApiInput]
 
 
 class _DiagnosticOptional(TypedDict, total=False):

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -1681,6 +1681,84 @@ function isToolCall(value) {
   return isObject3(value) && "args" in value && (value.id === undefined || typeof value.id === "string") && (value.name === undefined || typeof value.name === "string");
 }
 
+// src/letta-api.ts
+var DEFAULT_BASE_URL = "https://api.letta.com";
+var PAGE_SIZE = 100;
+async function normalizeLettaApi(input) {
+  validateInput(input);
+  const apiKey = input.apiKey ?? process.env.LETTA_API_KEY;
+  if (!apiKey) {
+    throw new NormalizationError("letta_api_auth_missing", "A Letta API key is required. Pass apiKey or set LETTA_API_KEY.");
+  }
+  const messages = await fetchAllMessages(input, apiKey);
+  return normalizeDecodedSession(lettaAdapter.decode(JSON.stringify(messages)), resolveBounds(input.bounds));
+}
+async function fetchAllMessages(input, apiKey) {
+  const messages = [];
+  let after;
+  for (;; ) {
+    const url = messagesUrl(input, after);
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: { Authorization: `Bearer ${apiKey}` }
+      });
+    } catch (error) {
+      throw new NormalizationError("letta_api_request_failed", `Failed to fetch Letta messages: ${errorMessage(error)}.`);
+    }
+    if (!response.ok) {
+      throw new NormalizationError("letta_api_request_failed", `Letta messages request failed with HTTP ${response.status}.`);
+    }
+    let page;
+    try {
+      page = await response.json();
+    } catch {
+      throw new NormalizationError("letta_api_response_invalid", "The Letta messages API returned invalid JSON.");
+    }
+    if (!Array.isArray(page) || !page.every(isObject4)) {
+      throw new NormalizationError("letta_api_response_invalid", "The Letta messages API response must be an array of message objects.");
+    }
+    messages.push(...page);
+    if (page.length < PAGE_SIZE)
+      break;
+    const lastId = page.at(-1)?.id;
+    if (typeof lastId !== "string" || !lastId || lastId === after) {
+      throw new NormalizationError("letta_api_response_invalid", "The Letta messages API returned a full page without a usable pagination cursor.");
+    }
+    after = lastId;
+  }
+  return messages;
+}
+function messagesUrl(input, after) {
+  const baseUrl = (input.baseUrl ?? process.env.LETTA_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const path = input.conversationId ? `/v1/conversations/${encodeURIComponent(input.conversationId)}/messages` : `/v1/agents/${encodeURIComponent(input.agentId)}/messages`;
+  const url = new URL(`${baseUrl}${path}`);
+  url.searchParams.set("limit", String(PAGE_SIZE));
+  url.searchParams.set("order", "asc");
+  if (after)
+    url.searchParams.set("after", after);
+  return url;
+}
+function validateInput(input) {
+  if (!input || typeof input !== "object") {
+    throw new NormalizationError("invalid_input", "Input must be an object.");
+  }
+  if (input.source !== "letta-api") {
+    throw new NormalizationError("unknown_source", `Letta API source must be "letta-api"; received ${JSON.stringify(input.source)}.`);
+  }
+  const hasConversation = typeof input.conversationId === "string" && input.conversationId.length > 0;
+  const hasAgent = typeof input.agentId === "string" && input.agentId.length > 0;
+  if (hasConversation === hasAgent) {
+    throw new NormalizationError("invalid_input", "Pass exactly one of conversationId or agentId.");
+  }
+}
+function isObject4(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 // src/index.ts
 var ADAPTERS = {
   "claude-code": claudeCodeAdapter,
@@ -1720,7 +1798,14 @@ async function main() {
   const results = [];
   for (const input of request.requests) {
     try {
-      const result = input !== null && typeof input === "object" && "source" in input && input.source === "deepagents" ? await normalizeCheckpoint(input) : normalizeTranscript(input);
+      let result;
+      if (input !== null && typeof input === "object" && "source" in input && input.source === "deepagents") {
+        result = await normalizeCheckpoint(input);
+      } else if (input !== null && typeof input === "object" && "source" in input && input.source === "letta-api") {
+        result = await normalizeLettaApi(input);
+      } else {
+        result = normalizeTranscript(input);
+      }
       results.push({
         ok: true,
         result

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { decodeDeepAgentsCheckpoint } from "./adapters/deepagents.js";
 import { resolveBounds } from "./bounds.js";
 import { normalizeDecodedSession } from "./core.js";
 import { loadDeepAgentsCheckpoint } from "./deepagents-checkpoint.js";
+import { normalizeLettaApi } from "./letta-api.js";
 import type { SourceAdapter } from "./internal.js";
 import type {
   DeepAgentsCheckpointInput,
@@ -66,6 +67,7 @@ export async function normalizeCheckpoint(
 }
 
 export { loadDeepAgentsCheckpoint } from "./deepagents-checkpoint.js";
+export { normalizeLettaApi };
 
 export { DEFAULT_NORMALIZATION_BOUNDS } from "./bounds.js";
 export { validateTranscript } from "./validate.js";
@@ -74,6 +76,7 @@ export {
   type AssistantMessageRecord,
   type AssistantToolCallRecord,
   type AnyTrajectorySource,
+  type ApiTrajectorySource,
   type CheckpointTrajectorySource,
   type Diagnostic,
   type DiagnosticCode,
@@ -85,6 +88,7 @@ export {
   type DeepAgentsMessageData,
   type DeepAgentsToolCall,
   type DeepAgentsToolMessageData,
+  type LettaApiInput,
   type MetaRecord,
   type NormalizationBounds,
   type NormalizationErrorCode,

--- a/src/letta-api.ts
+++ b/src/letta-api.ts
@@ -1,0 +1,134 @@
+import { normalizeDecodedSession } from "./core.js";
+import { lettaAdapter } from "./adapters/letta.js";
+import { resolveBounds } from "./bounds.js";
+import type { LettaApiInput, NormalizeResult } from "./types.js";
+import { NormalizationError } from "./types.js";
+
+const DEFAULT_BASE_URL = "https://api.letta.com";
+const PAGE_SIZE = 100;
+
+/** Fetch and normalize a complete remote Letta message history. */
+export async function normalizeLettaApi(
+  input: LettaApiInput,
+): Promise<NormalizeResult> {
+  validateInput(input);
+
+  const apiKey = input.apiKey ?? process.env.LETTA_API_KEY;
+  if (!apiKey) {
+    throw new NormalizationError(
+      "letta_api_auth_missing",
+      "A Letta API key is required. Pass apiKey or set LETTA_API_KEY.",
+    );
+  }
+
+  const messages = await fetchAllMessages(input, apiKey);
+  return normalizeDecodedSession(
+    lettaAdapter.decode(JSON.stringify(messages)),
+    resolveBounds(input.bounds),
+  );
+}
+
+async function fetchAllMessages(
+  input: LettaApiInput,
+  apiKey: string,
+): Promise<Record<string, unknown>[]> {
+  const messages: Record<string, unknown>[] = [];
+  let after: string | undefined;
+
+  for (;;) {
+    const url = messagesUrl(input, after);
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+    } catch (error) {
+      throw new NormalizationError(
+        "letta_api_request_failed",
+        `Failed to fetch Letta messages: ${errorMessage(error)}.`,
+      );
+    }
+
+    if (!response.ok) {
+      throw new NormalizationError(
+        "letta_api_request_failed",
+        `Letta messages request failed with HTTP ${response.status}.`,
+      );
+    }
+
+    let page: unknown;
+    try {
+      page = await response.json();
+    } catch {
+      throw new NormalizationError(
+        "letta_api_response_invalid",
+        "The Letta messages API returned invalid JSON.",
+      );
+    }
+    if (!Array.isArray(page) || !page.every(isObject)) {
+      throw new NormalizationError(
+        "letta_api_response_invalid",
+        "The Letta messages API response must be an array of message objects.",
+      );
+    }
+
+    messages.push(...page);
+    if (page.length < PAGE_SIZE) break;
+
+    const lastId = page.at(-1)?.id;
+    if (typeof lastId !== "string" || !lastId || lastId === after) {
+      throw new NormalizationError(
+        "letta_api_response_invalid",
+        "The Letta messages API returned a full page without a usable pagination cursor.",
+      );
+    }
+    after = lastId;
+  }
+
+  return messages;
+}
+
+function messagesUrl(input: LettaApiInput, after?: string): URL {
+  const baseUrl = (
+    input.baseUrl ??
+    process.env.LETTA_BASE_URL ??
+    DEFAULT_BASE_URL
+  ).replace(/\/$/, "");
+  const path = input.conversationId
+    ? `/v1/conversations/${encodeURIComponent(input.conversationId)}/messages`
+    : `/v1/agents/${encodeURIComponent(input.agentId as string)}/messages`;
+  const url = new URL(`${baseUrl}${path}`);
+  url.searchParams.set("limit", String(PAGE_SIZE));
+  url.searchParams.set("order", "asc");
+  if (after) url.searchParams.set("after", after);
+  return url;
+}
+
+function validateInput(input: LettaApiInput): void {
+  if (!input || typeof input !== "object") {
+    throw new NormalizationError("invalid_input", "Input must be an object.");
+  }
+  if (input.source !== "letta-api") {
+    throw new NormalizationError(
+      "unknown_source",
+      `Letta API source must be "letta-api"; received ${JSON.stringify(input.source)}.`,
+    );
+  }
+  const hasConversation =
+    typeof input.conversationId === "string" && input.conversationId.length > 0;
+  const hasAgent = typeof input.agentId === "string" && input.agentId.length > 0;
+  if (hasConversation === hasAgent) {
+    throw new NormalizationError(
+      "invalid_input",
+      "Pass exactly one of conversationId or agentId.",
+    );
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/python-cli.ts
+++ b/src/python-cli.ts
@@ -1,5 +1,9 @@
 import { readFileSync, writeFileSync } from "node:fs";
-import { normalizeCheckpoint, normalizeTranscript } from "./index.js";
+import {
+  normalizeCheckpoint,
+  normalizeLettaApi,
+  normalizeTranscript,
+} from "./index.js";
 import type { NormalizeResult } from "./types.js";
 import { NormalizationError } from "./types.js";
 
@@ -25,17 +29,30 @@ async function main(): Promise<void> {
   const results: WireResult[] = [];
   for (const input of request.requests) {
     try {
-      const result =
+      let result: NormalizeResult;
+      if (
         input !== null &&
         typeof input === "object" &&
         "source" in input &&
         input.source === "deepagents"
-          ? await normalizeCheckpoint(
-              input as Parameters<typeof normalizeCheckpoint>[0],
-            )
-          : normalizeTranscript(
-              input as Parameters<typeof normalizeTranscript>[0],
-            );
+      ) {
+        result = await normalizeCheckpoint(
+          input as Parameters<typeof normalizeCheckpoint>[0],
+        );
+      } else if (
+        input !== null &&
+        typeof input === "object" &&
+        "source" in input &&
+        input.source === "letta-api"
+      ) {
+        result = await normalizeLettaApi(
+          input as Parameters<typeof normalizeLettaApi>[0],
+        );
+      } else {
+        result = normalizeTranscript(
+          input as Parameters<typeof normalizeTranscript>[0],
+        );
+      }
       results.push({
         ok: true,
         result,

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,12 @@ export type TranscriptTrajectorySource = TrajectorySource;
 
 export type CheckpointTrajectorySource = "deepagents";
 
+export type ApiTrajectorySource = "letta-api";
+
 export type AnyTrajectorySource =
   | TranscriptTrajectorySource
-  | CheckpointTrajectorySource;
+  | CheckpointTrajectorySource
+  | ApiTrajectorySource;
 
 export interface ToolArgumentBounds {
   /** Maximum Unicode code points in the serialized arguments object. */
@@ -52,6 +55,19 @@ export interface DeepAgentsCheckpointLocation {
 export interface DeepAgentsCheckpointInput {
   source: "deepagents";
   checkpoint: DeepAgentsCheckpointLocation;
+  bounds?: NormalizationBounds;
+}
+
+export interface LettaApiInput {
+  source: "letta-api";
+  /** Fetch this conversation's complete remote message history. */
+  conversationId?: string;
+  /** Fetch the default conversation history for this legacy agent. */
+  agentId?: string;
+  /** Defaults to LETTA_API_KEY. */
+  apiKey?: string;
+  /** Defaults to https://api.letta.com. */
+  baseUrl?: string;
   bounds?: NormalizationBounds;
 }
 
@@ -194,6 +210,9 @@ export type NormalizationErrorCode =
   | "checkpoint_not_found"
   | "checkpoint_messages_missing"
   | "invalid_checkpoint_state"
+  | "letta_api_auth_missing"
+  | "letta_api_request_failed"
+  | "letta_api_response_invalid"
   | "missing_user_records"
   | "missing_assistant_records"
   | "invalid_normalized_transcript";

--- a/test/letta-api.test.ts
+++ b/test/letta-api.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeLettaApi, normalizeTranscript } from "../src/index.js";
+
+const userMessage = {
+  id: "message-user",
+  seq_id: 1,
+  message_type: "user_message",
+  content: "hello",
+  date: "2026-07-12T20:00:00.000Z",
+};
+const assistantMessage = {
+  id: "message-assistant",
+  seq_id: 2,
+  message_type: "assistant_message",
+  content: "hi",
+  date: "2026-07-12T20:00:01.000Z",
+};
+
+function systemMessage(index: number) {
+  return {
+    id: `message-system-${index}`,
+    seq_id: index + 3,
+    message_type: "system_message",
+    content: "ignored",
+    date: "2026-07-12T20:00:02.000Z",
+  };
+}
+
+describe("Letta API adapter", () => {
+  test("fetches every page and matches normalization of the same local transcript", async () => {
+    const firstPage = [
+      userMessage,
+      assistantMessage,
+      ...Array.from({ length: 98 }, (_, index) => systemMessage(index)),
+    ];
+    const secondPage = [systemMessage(98)];
+    const requests: URL[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push(url);
+        expect(request.headers.get("authorization")).toBe("Bearer test-key");
+        return Response.json(url.searchParams.has("after") ? secondPage : firstPage);
+      },
+    });
+
+    try {
+      const remote = await normalizeLettaApi({
+        source: "letta-api",
+        conversationId: "conv-test",
+        apiKey: "test-key",
+        baseUrl: server.url.toString(),
+      });
+      const local = normalizeTranscript({
+        source: "letta",
+        transcript: JSON.stringify([...firstPage, ...secondPage]),
+      });
+
+      expect(remote).toEqual(local);
+      expect(requests).toHaveLength(2);
+      expect(requests[0]?.pathname).toBe(
+        "/v1/conversations/conv-test/messages",
+      );
+      expect(requests[0]?.searchParams.get("order")).toBe("asc");
+      expect(requests[1]?.searchParams.get("after")).toBe(
+        "message-system-97",
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("uses the legacy agent messages endpoint", async () => {
+    let requestedPath = "";
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        requestedPath = new URL(request.url).pathname;
+        return Response.json([userMessage, assistantMessage]);
+      },
+    });
+
+    try {
+      await normalizeLettaApi({
+        source: "letta-api",
+        agentId: "agent-test",
+        apiKey: "test-key",
+        baseUrl: server.url.toString(),
+      });
+      expect(requestedPath).toBe("/v1/agents/agent-test/messages");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("requires exactly one remote history identifier", async () => {
+    expect(
+      normalizeLettaApi({ source: "letta-api", apiKey: "test-key" }),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+    expect(
+      normalizeLettaApi({
+        source: "letta-api",
+        conversationId: "conv-test",
+        agentId: "agent-test",
+        apiKey: "test-key",
+      }),
+    ).rejects.toMatchObject({ code: "invalid_input" });
+  });
+});


### PR DESCRIPTION
## Summary

- add an asynchronous `letta-api` adapter that fetches complete remote histories by conversation ID or legacy agent ID
- reuse the existing Letta decoder so API and local transcript inputs produce the same canonical `letta` records
- expose matching TypeScript and Python APIs, including authentication, base URL configuration, pagination, errors, tests, and documentation

Validated against a real stable Letta conversation: a local snapshot of 727 API messages and an independent `letta-api` fetch produced exactly the same 638 normalized records and diagnostics. The full repository check passes with 35 tests passing and 7 optional integration tests skipped.

👾 Generated with [Letta Code](https://letta.com)