### PR TITLE
ci: bump GitHub Actions Node.js from 20 to 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
## Summary

- Bumps `node-version` in `.github/workflows/ci.yml` from 20 to 24 (current LTS).
- Node.js 20 reaches end-of-life on 2026-04-30.
- The package declares `"engines": { "node": ">=20" }` and uses Bun 1.3.0 for all test/build scripts, so Node 24 is fully compatible.

## Validation

- YAML parsed successfully; `node-version` field confirmed as `24`.
- Diff is a single one-line change.

Refs: [LET-9782](https://linear.app/letta/issue/LET-9782/migrate-github-hosted-workflows-off-nodejs-20)