### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,33 @@ build/test it and consume it as an imported library.
   and run with `DEEPAGENTS_TEST_PYTHON=python DEEPAGENTS_SDK_TEST_PYTHON=python bun test ...`.
   These are optional; a clean `bun run check` + Python parity run is sufficient for
   most work.
+
+## Canonical-contract work: invariants and review learnings
+
+The canonical view (`normalizeToCanonical`, see `CANONICAL.md`) is a frozen
+cross-repo contract consumed by the letta-cloud normalizer worker. Changes here
+went through several avoidable review rounds; hold these invariants explicitly
+from the start and self-audit against them **before** requesting review:
+
+- **Chunk-stable identity.** A given source record must produce identical
+  `stable_source_record_id` / `record_id` / `source_order_id` / `content_hash`
+  whether it is normalized in the full transcript or in a standalone
+  continuation chunk, and regardless of transport-arrival order. Never derive
+  identity from content, in-transcript position, or synthesized timestamps.
+- **Per-adapter anchor semantics differ.** Identity anchors are `byte` (JSONL
+  byte-cursor sources: Claude Code, Codex, local Letta) vs `ordinal` (whole
+  decode: Deep Agents). `sourceContext.baseByteOffset` applies only to `byte`
+  anchors; the unit is part of the identity tuple. Group must be authoritative
+  and stable across chunks (worker-supplied `sourceContext.groupId` fills a
+  missing detected group; disagreement fails). Audit **every** adapter, not just
+  the one you changed.
+- **Continuation chunks are partial.** `baseByteOffset > 0` ⇒ partial mode: omit
+  meta, don't require user/assistant turns, and keep cross-chunk tool results
+  (call in an earlier chunk) instead of dropping them. `normalizeTranscript()`
+  stays strict. Single-line JSONL continuations still parse (route lone wrapper
+  rows through the local parser).
+- **Process:** for contract-heavy tickets, ask the design authority (Amelia) to
+  *red-team* the invariants ("what breaks under chunking / partial uploads / each
+  adapter's anchor?"), not just to approve a proposed shape — a prose proposal
+  hides bugs that a diff review finds. Then do a per-adapter self-audit against
+  the invariants above before undrafting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`trajectory` is a **library** (TypeScript core in `src/` published to npm as
+`@letta-ai/trajectory`, plus a thin Python wrapper in `python/` published as
+`letta-trajectory`). There is **no server, database, or `dev` command** — you
+build/test it and consume it as an imported library.
+
+### Toolchain
+- **Bun 1.3.0** is the package manager, test runner, and bundler. It is installed
+  at `~/.bun/bin/bun` (added to `PATH` via `~/.bashrc`, so interactive shells find
+  `bun` automatically; non-interactive scripts should use the full path).
+- **Node.js 20+** and **Python 3.10+** are required. The Python wrapper does not
+  run normalization itself — it spawns Node as a subprocess to execute the
+  bundled `trajectory-cli.mjs`, so Node must be on `PATH`.
+
+### Commands (see `README.md` and `package.json` scripts)
+- `bun install --frozen-lockfile` — install JS deps (the `prepare` script runs
+  `build` automatically).
+- `bun run check` — the main gate: regenerates the vendored Python CLI bundle,
+  fails if the committed bundle is stale, then typechecks (`tsc`), runs `bun test`,
+  and builds `dist/`.
+- `bun run typecheck`, `bun test`, `bun run build` — individual steps.
+- `PYTHONPATH=python/src python3 -m unittest discover -s python/tests -v` — Python
+  parity suite.
+
+### Non-obvious gotchas
+- **Regenerate the vendored bundle after editing TS core.** `bun run check`
+  runs `bun run build:python-cli` then `git diff --exit-code` on
+  `python/src/trajectory/_vendor/trajectory-cli.mjs` (and `deepagents_checkpoint.py`).
+  If you change TypeScript in `src/` and forget to regenerate, `check` fails on a
+  dirty git diff. Run `bun run build:python-cli` and commit the regenerated bundle.
+- **Deep Agents tests skip by default.** The `deepagents` TS tests and the Python
+  `test_normalizes_deepagents_checkpoint_with_current_python` are skipped unless the
+  optional extras are installed: `python -m pip install ".[deepagents]" "deepagents>=0.6,<0.7"`
+  and run with `DEEPAGENTS_TEST_PYTHON=python DEEPAGENTS_SDK_TEST_PYTHON=python bun test ...`.
+  These are optional; a clean `bun run check` + Python parity run is sufficient for
+  most work.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `trajectory` library (TypeScript core + Python wrapper) in Cursor Cloud and documents durable operating guidance for future agents.

## Changes
- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the toolchain (Bun 1.3.0, Node 20+, Python 3.10+), the main commands, and non-obvious gotchas (regenerating the vendored Python CLI bundle after TS edits; Deep Agents tests skipping without optional extras).
- Add a `## Canonical-contract work: invariants and review learnings` section capturing the chunk-stable identity / per-adapter anchor / partial-continuation invariants for `normalizeToCanonical`, plus a process note to red-team invariants with the design authority and self-audit per-adapter before requesting review.

## Environment setup
The startup update script installs Bun 1.3.0 (if missing) and runs `bun install --frozen-lockfile`. No code changes were required — the repo was already working.

## Verification
- `bun run check` — typecheck + tests + build.
- `PYTHONPATH=python/src python3 -m unittest discover -s python/tests -v` — Python parity.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

