### PR TITLE
Publish @letta-ai/trajectory without provenance (unblock private repo)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,13 @@ on:
 
 permissions:
   contents: read
-  # Required for npm provenance (OIDC).
+  # Kept for when provenance is re-enabled (see the publish step); npm provenance
+  # requires OIDC. Unused while publishing without provenance.
   id-token: write
 
 jobs:
   publish:
-    name: Publish to npm with provenance
+    name: Publish to npm
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -37,7 +38,12 @@ jobs:
       - name: Verify (typecheck, test, build)
         run: bun run check
 
-      - name: Publish with provenance
-        run: npm publish --provenance --access public
+      # NOTE: provenance (`--provenance`) requires a PUBLIC GitHub source repo;
+      # npm rejects it for a private repo (422). This repo is currently private,
+      # so we publish without provenance to unblock consumers. Re-add
+      # `--provenance` once the repo is public (a later release will then be
+      # provenance-signed); no other change is needed.
+      - name: Publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `v0.1.0` publish run failed: npm rejects `--provenance` for a **private** source repo (`422 Unsupported GitHub Actions source repository visibility: "private"`). The package was not published.

Per Caren: unblock consumers now by publishing **without** provenance, and switch back to provenance once the repo is made public.

## Change

- `publish.yml`: drop `--provenance` from the publish step (keep `id-token: write` and a comment so re-enabling provenance is a one-line change).

## Follow-up (Option A, later)

Provenance is per-publish, so this doesn't lock anything in: once `letta-ai/trajectory` is public, re-add `--provenance` and a subsequent release (e.g. `0.1.1`) will be provenance-signed. No republish of `0.1.0` is needed for that.

## After merge

Trigger the workflow (`workflow_dispatch`) to publish `0.1.0`, then smoke-check the registry (clean install, verify `NORMALIZER_VERSION` / `CANONICAL_SCHEMA_VERSION`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

