### PR TITLE
docs: install from the published npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,6 @@ The TypeScript package is published as
 npm install @letta-ai/trajectory
 ```
 
-The Python distribution is named `letta-trajectory` and imports as
-`trajectory`. It includes the bundled normalizer and has no Python runtime
-dependencies, but it requires Node.js 20 or newer. It is not yet published to
-PyPI; install it from GitHub:
-
-```sh
-pip install "letta-trajectory @ git+ssh://git@github.com/letta-ai/trajectory.git"
-```
-
 ## Quick start
 
 ```ts
@@ -40,31 +31,6 @@ const { records, diagnostics } = normalizeTranscript({
   source: "codex",
   transcript: rawJsonl,
 });
-```
-
-The Python wrapper exposes the same inputs and returns ordinary dictionaries:
-
-```python
-from trajectory import normalize_transcript
-
-result = normalize_transcript(
-    source="codex",
-    transcript=raw_jsonl,
-)
-records = result["records"]
-diagnostics = result["diagnostics"]
-```
-
-For training pipelines, `normalize_many()` sends a complete batch through one
-Node process instead of starting a process for every transcript:
-
-```python
-from trajectory import normalize_many
-
-results = normalize_many([
-    {"source": "codex", "transcript": codex_jsonl},
-    {"source": "letta", "transcript": letta_json},
-])
 ```
 
 `records` contains the normalized trajectory. `diagnostics` is always present
@@ -136,9 +102,6 @@ do {
   cursor = page.nextCursor;
 } while (cursor);
 ```
-
-The Python wrapper mirrors it as `list_trajectories(source=..., root=None,
-cursor=None, limit=None)`.
 
 Each item's `path` is the locator for the next step: the transcript file to
 read (`claude-code`, `codex`, `letta`, `openclaw`), the SQLite store holding

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ LangGraph SQLite store by thread ID; see
 
 ## Installation
 
-Neither package has been published yet. Install the TypeScript package directly
-from GitHub:
+The TypeScript package is published as
+[`@letta-ai/trajectory`](https://www.npmjs.com/package/@letta-ai/trajectory):
 
 ```sh
-npm install github:letta-ai/trajectory
+npm install @letta-ai/trajectory
 ```
 
 The Python distribution is named `letta-trajectory` and imports as
 `trajectory`. It includes the bundled normalizer and has no Python runtime
-dependencies, but it requires Node.js 20 or newer:
+dependencies, but it requires Node.js 20 or newer. It is not yet published to
+PyPI; install it from GitHub:
 
 ```sh
 pip install "letta-trajectory @ git+ssh://git@github.com/letta-ai/trajectory.git"


### PR DESCRIPTION
README installation now uses `npm install @letta-ai/trajectory` (0.1.0 is live: https://www.npmjs.com/package/@letta-ai/trajectory) and the Python distribution is no longer mentioned in the README — no pip install section, no Python quick-start examples, no wrapper notes. The only remaining Python references are in the Development section (the repo's own parity checks) and the deepagents adapter README (its decoder requires a Python interpreter). Docs-only.