### PR TITLE
feat: preserve source-native tool result status

### DIFF
--- a/CANONICAL.md
+++ b/CANONICAL.md
@@ -44,7 +44,7 @@ fields it must compute from stored cross-upload state.
 | `record_hash` | library | sha256 of `record_json` (64-hex) |
 | `content_hash` | library | sha256 of canonical semantic content, excluding transport metadata/timestamps (64-hex) |
 | `source_timestamp`, `record_timestamp` | library | descriptive only, never a cursor; nullable |
-| `content`, `tool_call_id`, `tool_name`, `tool_arguments_json`, `tool_result_json` | library | nullable flattened fields |
+| `content`, `tool_call_id`, `tool_name`, `tool_arguments_json`, `tool_result_json`, `tool_result_ok` | library | nullable flattened fields; `tool_result_ok` is `true`/`false` only for source-native structured outcomes and otherwise `null` |
 | `record_json` | library | lossless canonical JSON of the emitted trajectory-v1 record |
 | `organization_id`, `workspace_id`, `user_id`, `source_id`, `source_upload_id` | worker | tenancy + raw-upload lineage |
 | `ingestion_id`, `ingested_at` | worker | opaque monotonic ingestion identity — the Dream cursor key |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ and is empty when the transcript required no recoverable cleanup.
 | [`pi`](src/adapters/pi/) | Native pi-coding-agent session JSONL | `pi` |
 | [`deepagents`](src/adapters/deepagents/) | Deep Agents CLI LangGraph SQLite store plus `threadId` | `deepagents` |
 
+Tool result records may include `ok: boolean` when the source exposes an
+authoritative structured outcome, such as Pi/OpenClaw `isError`, Claude Code
+`is_error`, Letta Code `resultOk`, or OpenHands observation `is_error`. The
+field is omitted when the source does not expose a reliable status; result text
+is never interpreted as success or failure.
+
 Each adapter lives in its own folder under [`src/adapters/`](src/adapters/)
 with a README documenting the exact input contract, decoding behavior, and
 what the adapter drops.

--- a/docs/logs/implementation-notes-native-tool-result-status.md
+++ b/docs/logs/implementation-notes-native-tool-result-status.md
@@ -1,0 +1,7 @@
+# Native Tool Result Status Implementation Notes
+
+## Canonical unknown representation
+
+The initial RED test expected `tool_result_ok: null` for Codex. During the first GREEN pass the field was made optional and the assertion changed to `undefined`. Review identified that this would introduce the canonical schema's first optional flattened field and leave workers to distinguish missing from null.
+
+The final contract keeps normalized trajectory-v1 additive with optional `ToolResultRecord.ok`, but canonical schema v2 makes `tool_result_ok` required and nullable like the existing flattened fields. Sources with authoritative booleans emit `true` or `false`; Codex and other sources without one emit `null`. Native status remains part of semantic content hashing, so canonical schema version advances to 2.

--- a/docs/logs/implementation-notes-native-tool-result-status.md
+++ b/docs/logs/implementation-notes-native-tool-result-status.md
@@ -1,7 +1,0 @@
-# Native Tool Result Status Implementation Notes
-
-## Canonical unknown representation
-
-The initial RED test expected `tool_result_ok: null` for Codex. During the first GREEN pass the field was made optional and the assertion changed to `undefined`. Review identified that this would introduce the canonical schema's first optional flattened field and leave workers to distinguish missing from null.
-
-The final contract keeps normalized trajectory-v1 additive with optional `ToolResultRecord.ok`, but canonical schema v2 makes `tool_result_ok` required and nullable like the existing flattened fields. Sources with authoritative booleans emit `true` or `false`; Codex and other sources without one emit `null`. Native status remains part of semantic content hashing, so canonical schema version advances to 2.

--- a/fixtures/canonical/claude-code__tool-call.json
+++ b/fixtures/canonical/claude-code__tool-call.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"cwd\":\"/workspace/project\",\"git_branch\":\"main\",\"model\":\"claude-opus-4-6\",\"role\":\"meta\",\"source\":\"claude-code\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"fix the flaky retry test\",\"role\":\"user\",\"timestamp\":\"2026-03-06T14:15:22.394Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"check the retry module\",\"role\":\"reasoning\",\"timestamp\":\"2026-03-06T14:15:30.000Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Looking at retry.py now.\",\"role\":\"assistant\",\"timestamp\":\"2026-03-06T14:15:30.000Z\"}"
     },
     {
@@ -98,6 +102,7 @@
       "tool_name": "Read",
       "tool_arguments_json": "{\"file_path\":\"retry.py\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-03-06T14:15:30.000Z\",\"tool_calls\":[{\"args\":\"{\\\"file_path\\\":\\\"retry.py\\\"}\",\"id\":\"toolu_01A\",\"name\":\"Read\"}]}"
     },
     {
@@ -109,8 +114,8 @@
       "component_index": 0,
       "record_type": "tool",
       "record_id": "3c660c57b62dfb1b8e1afb3cbbf61bded34a99a6ede918cc4bac6b8b2605edf0",
-      "record_hash": "2af8eb886c40ba853b9c5412e1cd47590750da2b538fd2520fb74eb9d14d1cb7",
-      "content_hash": "bd3f23233825598e5849604171e58e9b37c493c17b4e55a74664f9b28222568e",
+      "record_hash": "c6e05ac6a12cc0f02cc3c7cf1fba845cfebbf6b81c443b3cc6b465163652e76d",
+      "content_hash": "e6d1daed2435781633b89ec8c15dad6af070aac064f3ec89fbe37cc4e348e031",
       "source_timestamp": "2026-03-06T14:15:31.000Z",
       "record_timestamp": "2026-03-06T14:15:31.000Z",
       "content": null,
@@ -118,7 +123,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "1\tdef retry():",
-      "record_json": "{\"content\":\"1\\tdef retry():\",\"role\":\"tool\",\"timestamp\":\"2026-03-06T14:15:31.000Z\",\"tool_call_id\":\"toolu_01A\"}"
+      "tool_result_ok": false,
+      "record_json": "{\"content\":\"1\\tdef retry():\",\"ok\":false,\"role\":\"tool\",\"timestamp\":\"2026-03-06T14:15:31.000Z\",\"tool_call_id\":\"toolu_01A\"}"
     },
     {
       "source_type": "claude-code",
@@ -138,16 +144,14 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Patched the backoff.\",\"role\":\"assistant\",\"timestamp\":\"2026-03-06T14:15:33.000Z\"}"
     }
   ],
   "diagnostics": [],
-  "normalizer_version": "0.1.0",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -156,6 +160,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/codex__tool-calls.json
+++ b/fixtures/canonical/codex__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"cwd\":\"/workspace/project\",\"git_branch\":\"feature/retry\",\"model\":\"gpt-5.3-codex\",\"role\":\"meta\",\"source\":\"codex\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"create one focused commit\",\"role\":\"user\",\"timestamp\":\"2026-03-30T05:38:34.725Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Reviewing the changed files\",\"role\":\"reasoning\",\"timestamp\":\"2026-03-30T05:38:45.000Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": "update_plan",
       "tool_arguments_json": "{\"explanation\":\"review and commit\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-03-30T05:38:50.441Z\",\"tool_calls\":[{\"args\":\"{\\\"explanation\\\":\\\"review and commit\\\"}\",\"id\":\"call_A\",\"name\":\"update_plan\"}]}"
     },
     {
@@ -98,6 +102,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "Plan updated",
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Plan updated\",\"role\":\"tool\",\"timestamp\":\"2026-03-30T05:38:50.585Z\",\"tool_call_id\":\"call_A\"}"
     },
     {
@@ -118,6 +123,7 @@
       "tool_name": "apply_patch",
       "tool_arguments_json": "{\"input\":\"*** Begin Patch\\n*** End Patch\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-03-30T05:39:00.000Z\",\"tool_calls\":[{\"args\":\"{\\\"input\\\":\\\"*** Begin Patch\\\\n*** End Patch\\\"}\",\"id\":\"call_B\",\"name\":\"apply_patch\"}]}"
     },
     {
@@ -138,6 +144,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "Done",
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Done\",\"role\":\"tool\",\"timestamp\":\"2026-03-30T05:39:00.100Z\",\"tool_call_id\":\"call_B\"}"
     },
     {
@@ -158,6 +165,7 @@
       "tool_name": "tool_search",
       "tool_arguments_json": "{\"query\":\"filesystem tools\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-03-30T05:39:30.000Z\",\"tool_calls\":[{\"args\":\"{\\\"query\\\":\\\"filesystem tools\\\"}\",\"id\":\"call_C\",\"name\":\"tool_search\"}]}"
     },
     {
@@ -178,6 +186,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "[{\"name\":\"read_file\"}]",
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"[{\\\"name\\\":\\\"read_file\\\"}]\",\"role\":\"tool\",\"timestamp\":\"2026-03-30T05:39:30.100Z\",\"tool_call_id\":\"call_C\"}"
     },
     {
@@ -198,6 +207,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Created one focused commit.\",\"role\":\"assistant\",\"timestamp\":\"2026-03-30T05:40:43.000Z\"}"
     }
   ],
@@ -208,12 +218,9 @@
       "inputLine": 3
     }
   ],
-  "normalizer_version": "0.1.0",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -222,6 +229,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/hermes__tool-calls.json
+++ b/fixtures/canonical/hermes__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"cwd\":\"/workspace/demo\",\"model\":\"gpt-5.2\",\"role\":\"meta\",\"source\":\"hermes\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Check the current directory.\",\"role\":\"user\",\"timestamp\":\"2026-07-02T13:46:41.250Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"The user wants the working directory; run pwd.\",\"role\":\"reasoning\",\"timestamp\":\"2026-07-02T13:46:44.500Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": "terminal",
       "tool_arguments_json": "{\"command\":\"pwd\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-02T13:46:44.500Z\",\"tool_calls\":[{\"args\":\"{\\\"command\\\":\\\"pwd\\\"}\",\"id\":\"call_hermes_1\",\"name\":\"terminal\"}]}"
     },
     {
@@ -98,6 +102,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "/workspace/demo",
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"/workspace/demo\",\"role\":\"tool\",\"timestamp\":\"2026-07-02T13:46:46.000Z\",\"tool_call_id\":\"call_hermes_1\"}"
     },
     {
@@ -118,16 +123,14 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"You are in /workspace/demo.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-02T13:46:48.750Z\"}"
     }
   ],
   "diagnostics": [],
-  "normalizer_version": "0.1.0",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -136,6 +139,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/letta-code__tool-calls.json
+++ b/fixtures/canonical/letta-code__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"role\":\"meta\",\"source\":\"letta-code\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Inspect the entry point.\",\"role\":\"user\",\"timestamp\":\"2026-07-22T12:00:00.000Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"I should read the file first.\",\"role\":\"reasoning\",\"timestamp\":\"2026-07-22T12:00:01.000Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"I will inspect it now.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-22T12:00:01.000Z\"}"
     },
     {
@@ -98,6 +102,7 @@
       "tool_name": "Read",
       "tool_arguments_json": "{\"file_path\":\"src/app.ts\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-22T12:00:02.000Z\",\"tool_calls\":[{\"args\":\"{\\\"file_path\\\":\\\"src/app.ts\\\"}\",\"id\":\"call-read-1\",\"name\":\"Read\"}]}"
     },
     {
@@ -109,8 +114,8 @@
       "component_index": 1,
       "record_type": "tool",
       "record_id": "53d517a48a8be36793baf70ece96089cde53c3957026dcefecbb96df927db225",
-      "record_hash": "31b58727422ed18a3507df67dba1de934fb2204c06bc5483aca3c5db49af9891",
-      "content_hash": "0462d6b714053e5ce7e58b8d0c40fa3fc41b99e2bdc8e5b2c48773b715b1744f",
+      "record_hash": "05d59e2405ecfdcebf664402c40cc29fe9dfb0dde4c75c541f2662ca5bd2418e",
+      "content_hash": "cd065815738be662b3ecddfce68bb1bf226719a46a12c4112e04fe3e862795ce",
       "source_timestamp": "2026-07-22T12:00:02.000Z",
       "record_timestamp": "2026-07-22T12:00:02.000Z",
       "content": null,
@@ -118,7 +123,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "export const value = 1;",
-      "record_json": "{\"content\":\"export const value = 1;\",\"role\":\"tool\",\"timestamp\":\"2026-07-22T12:00:02.000Z\",\"tool_call_id\":\"call-read-1\"}"
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"export const value = 1;\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-07-22T12:00:02.000Z\",\"tool_call_id\":\"call-read-1\"}"
     },
     {
       "source_type": "letta-code",
@@ -138,16 +144,14 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"The entry point exports value 1.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-22T12:00:03.000Z\"}"
     }
   ],
   "diagnostics": [],
-  "normalizer_version": "0.1.1",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -156,6 +160,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/openclaw__tool-calls.json
+++ b/fixtures/canonical/openclaw__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"cwd\":\"/home/user/workspace\",\"model\":\"claude-opus-4-8\",\"role\":\"meta\",\"source\":\"openclaw\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"What files are in the workspace?\",\"role\":\"user\",\"timestamp\":\"2026-07-05T09:00:01.000Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"A directory listing answers this directly.\",\"role\":\"reasoning\",\"timestamp\":\"2026-07-05T09:00:04.000Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": "bash",
       "tool_arguments_json": "{\"command\":\"ls\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-05T09:00:04.000Z\",\"tool_calls\":[{\"args\":\"{\\\"command\\\":\\\"ls\\\"}\",\"id\":\"call_oc_1\",\"name\":\"bash\"}]}"
     },
     {
@@ -89,8 +93,8 @@
       "component_index": 0,
       "record_type": "tool",
       "record_id": "d534477fdc263287d1d1023e8e83e6e9cbabcd6883a43710acb3b0737ab3dae9",
-      "record_hash": "458dd9c6b53ea0cd607fcfdfa0f9c2ca8d2161d69ef8788387398f5d4a636520",
-      "content_hash": "be96bd11f2558969cc1765b6d5dcddfeebbaf7a4174d276f1fd0ddb688470d12",
+      "record_hash": "6f61213357d468fb420301b264e8f6889cb2a02b56768394452ec27065303921",
+      "content_hash": "4298bbe9bb643da71fe260429f16a21e3ff5ad37037ebe8181e869e2e9d5c8c9",
       "source_timestamp": "2026-07-05T09:00:05.500Z",
       "record_timestamp": "2026-07-05T09:00:05.500Z",
       "content": null,
@@ -98,7 +102,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "README.md\nsrc\n",
-      "record_json": "{\"content\":\"README.md\\nsrc\\n\",\"role\":\"tool\",\"timestamp\":\"2026-07-05T09:00:05.500Z\",\"tool_call_id\":\"call_oc_1\"}"
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"README.md\\nsrc\\n\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-07-05T09:00:05.500Z\",\"tool_call_id\":\"call_oc_1\"}"
     },
     {
       "source_type": "openclaw",
@@ -118,16 +123,14 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"The workspace contains README.md and a src directory.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-05T09:00:08.000Z\"}"
     }
   ],
   "diagnostics": [],
-  "normalizer_version": "0.1.0",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -136,6 +139,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/openhands__tool-calls.json
+++ b/fixtures/canonical/openhands__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"role\":\"meta\",\"source\":\"openhands\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Inspect and update the entry point.\",\"role\":\"user\",\"timestamp\":\"2026-07-03T10:00:00.000Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"I'll inspect the workspace first.\",\"role\":\"reasoning\",\"timestamp\":\"2026-07-03T10:00:01.000Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": "terminal",
       "tool_arguments_json": "{\"command\":\"pwd\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-03T10:00:01.000Z\",\"tool_calls\":[{\"args\":\"{\\\"command\\\":\\\"pwd\\\"}\",\"id\":\"call_oh_1\",\"name\":\"terminal\"}]}"
     },
     {
@@ -89,8 +93,8 @@
       "component_index": 0,
       "record_type": "tool",
       "record_id": "a6b6e7de4eba2a340ab448bb74524405afa9c7ed84cff74c7a9aacc64e9b2fd7",
-      "record_hash": "e15a47f49265498187eaaaa5208ecdc33be64ddce55d629cd234042967498c84",
-      "content_hash": "47bd2e2adc81b0332e9e02c914cafe27c8446fb883a44f22d6821acca53c58c4",
+      "record_hash": "8730ee8cd7311df60ade508be48b48d2327033a54b9f92a209969ebe8d8925af",
+      "content_hash": "a3246ba169dc4ed8ed3b48f3fd3e4879645c57195381e5a8afb35971bc07922d",
       "source_timestamp": "2026-07-03T10:00:02.000Z",
       "record_timestamp": "2026-07-03T10:00:02.000Z",
       "content": null,
@@ -98,7 +102,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "/workspace\nready",
-      "record_json": "{\"content\":\"/workspace\\nready\",\"role\":\"tool\",\"timestamp\":\"2026-07-03T10:00:02.000Z\",\"tool_call_id\":\"call_oh_1\"}"
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"/workspace\\nready\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-07-03T10:00:02.000Z\",\"tool_call_id\":\"call_oh_1\"}"
     },
     {
       "source_type": "openhands",
@@ -118,6 +123,7 @@
       "tool_name": "file_editor",
       "tool_arguments_json": "{\"path\":\"src/app.ts\",\"content\":\"updated\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-03T10:00:03.000Z\",\"tool_calls\":[{\"args\":\"{\\\"path\\\":\\\"src/app.ts\\\",\\\"content\\\":\\\"updated\\\"}\",\"id\":\"oh_action-2\",\"name\":\"file_editor\"}]}"
     },
     {
@@ -138,6 +144,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "Edit was not approved.",
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Edit was not approved.\",\"role\":\"tool\",\"timestamp\":\"2026-07-03T10:00:04.000Z\",\"tool_call_id\":\"oh_action-2\"}"
     },
     {
@@ -158,16 +165,14 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"I inspected the workspace; the edit was rejected.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-03T10:00:05.000Z\"}"
     }
   ],
   "diagnostics": [],
-  "normalizer_version": "0.1.0",
-  "canonical_schema_version": 1,
+  "normalizer_version": "0.2.0",
+  "canonical_schema_version": 2,
   "config": {
-    "filters": {
-      "toolResults": "include"
-    },
     "bounds": {
       "toolArguments": {
         "maxCharacters": 20000
@@ -176,6 +181,9 @@
         "maxCharacters": 2500,
         "strategy": "head-tail"
       }
+    },
+    "filters": {
+      "toolResults": "include"
     }
   }
 }

--- a/fixtures/canonical/pi__tool-calls.json
+++ b/fixtures/canonical/pi__tool-calls.json
@@ -18,6 +18,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"cwd\":\"/home/user/pi-demo\",\"model\":\"claude-sonnet-5\",\"role\":\"meta\",\"source\":\"pi\"}"
     },
     {
@@ -38,6 +39,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Create notes.txt with a short todo list, then show it with bash.\",\"role\":\"user\",\"timestamp\":\"2026-07-24T06:21:03.547Z\"}"
     },
     {
@@ -58,6 +60,7 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"I need to create notes.txt with the requested content, then display it.\",\"role\":\"reasoning\",\"timestamp\":\"2026-07-24T06:21:03.578Z\"}"
     },
     {
@@ -78,6 +81,7 @@
       "tool_name": "write",
       "tool_arguments_json": "{\"path\":\"notes.txt\",\"content\":\"TODO:\\n- collect pi traces\\n- write the adapter\\n\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-24T06:21:03.578Z\",\"tool_calls\":[{\"args\":\"{\\\"path\\\":\\\"notes.txt\\\",\\\"content\\\":\\\"TODO:\\\\n- collect pi traces\\\\n- write the adapter\\\\n\\\"}\",\"id\":\"toolu_pi_1\",\"name\":\"write\"}]}"
     },
     {
@@ -89,8 +93,8 @@
       "component_index": 0,
       "record_type": "tool",
       "record_id": "8f17fee2952ec774c1e3877967b7a80d054dde33f5adcdb445d8ab06f21040be",
-      "record_hash": "138c02b75bff466ceb190a55567b6bde99ab5084a1332d827379e814e575a00f",
-      "content_hash": "8a9fde41836e549c7d271ad10ccbc97bc6344a7ccb80759a9501481544d47bfa",
+      "record_hash": "b532d53e693260be03ac5fbe2376c915f8d4df254fd522a09660674ec1e84ab6",
+      "content_hash": "cfabb5b8a3e03b35d42dc565460e200648329eef46acdeae7d79b3577f516688",
       "source_timestamp": "2026-07-24T06:21:03.580Z",
       "record_timestamp": "2026-07-24T06:21:03.580Z",
       "content": null,
@@ -98,7 +102,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "Successfully wrote 46 bytes to notes.txt",
-      "record_json": "{\"content\":\"Successfully wrote 46 bytes to notes.txt\",\"role\":\"tool\",\"timestamp\":\"2026-07-24T06:21:03.580Z\",\"tool_call_id\":\"toolu_pi_1\"}"
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"Successfully wrote 46 bytes to notes.txt\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-07-24T06:21:03.580Z\",\"tool_call_id\":\"toolu_pi_1\"}"
     },
     {
       "source_type": "pi",
@@ -118,6 +123,7 @@
       "tool_name": "bash",
       "tool_arguments_json": "{\"command\":\"cat notes.txt\"}",
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-07-24T06:21:03.585Z\",\"tool_calls\":[{\"args\":\"{\\\"command\\\":\\\"cat notes.txt\\\"}\",\"id\":\"toolu_pi_2\",\"name\":\"bash\"}]}"
     },
     {
@@ -129,8 +135,8 @@
       "component_index": 0,
       "record_type": "tool",
       "record_id": "ae62f856064616065f75f9b0413850fec9878088c7a243a94cc6eb33c5483a4c",
-      "record_hash": "cabd8be38b1a81502fa2a86290f705824187fe5a56cf52e78e943051a24ad594",
-      "content_hash": "ec62ef72aa077ffffe0453418fc4c399c614898538ea610b9a2ff07273302093",
+      "record_hash": "65357522295d448f70ca59a49b99db74576c507ecf69a4a2a925c163be2fa143",
+      "content_hash": "6d41f362736db63ffcd5ddb9c1fec8394bcaed294ee9b88611d0e0eb1219d42f",
       "source_timestamp": "2026-07-24T06:21:03.640Z",
       "record_timestamp": "2026-07-24T06:21:03.640Z",
       "content": null,
@@ -138,7 +144,8 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": "TODO:\n- collect pi traces\n- write the adapter\n",
-      "record_json": "{\"content\":\"TODO:\\n- collect pi traces\\n- write the adapter\\n\",\"role\":\"tool\",\"timestamp\":\"2026-07-24T06:21:03.640Z\",\"tool_call_id\":\"toolu_pi_2\"}"
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"TODO:\\n- collect pi traces\\n- write the adapter\\n\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-07-24T06:21:03.640Z\",\"tool_call_id\":\"toolu_pi_2\"}"
     },
     {
       "source_type": "pi",
@@ -158,12 +165,13 @@
       "tool_name": null,
       "tool_arguments_json": null,
       "tool_result_json": null,
+      "tool_result_ok": null,
       "record_json": "{\"content\":\"Done. I created `notes.txt` with a short TODO list and displayed its contents above.\",\"role\":\"assistant\",\"timestamp\":\"2026-07-24T06:21:03.700Z\"}"
     }
   ],
   "diagnostics": [],
   "normalizer_version": "0.2.0",
-  "canonical_schema_version": 1,
+  "canonical_schema_version": 2,
   "config": {
     "bounds": {
       "toolArguments": {

--- a/fixtures/claude-code/tool-call/expected.json
+++ b/fixtures/claude-code/tool-call/expected.json
@@ -38,6 +38,7 @@
       "role": "tool",
       "tool_call_id": "toolu_01A",
       "content": "1\tdef retry():",
+      "ok": false,
       "timestamp": "2026-03-06T14:15:31.000Z"
     },
     {

--- a/fixtures/claude-code/tool-call/input.jsonl
+++ b/fixtures/claude-code/tool-call/input.jsonl
@@ -1,4 +1,4 @@
 {"type":"user","uuid":"u1","parentUuid":null,"isSidechain":false,"cwd":"/workspace/project","gitBranch":"main","timestamp":"2026-03-06T14:15:22.394Z","message":{"role":"user","content":"fix the flaky retry test"}}
 {"type":"assistant","uuid":"a1","timestamp":"2026-03-06T14:15:30.000Z","message":{"role":"assistant","model":"claude-opus-4-6","content":[{"type":"thinking","thinking":"check the retry module"},{"type":"text","text":"Looking at retry.py now."},{"type":"tool_use","id":"toolu_01A","name":"Read","input":{"file_path":"retry.py"}}]}}
-{"type":"user","uuid":"u2","timestamp":"2026-03-06T14:15:31.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01A","content":[{"type":"text","text":"1\tdef retry():"}]}]}}
+{"type":"user","uuid":"u2","timestamp":"2026-03-06T14:15:31.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01A","content":[{"type":"text","text":"1\tdef retry():"}],"is_error":true}]}}
 {"type":"assistant","uuid":"a2","timestamp":"2026-03-06T14:15:33.000Z","message":{"role":"assistant","model":"claude-opus-4-6","content":[{"type":"text","text":"Patched the backoff."}]}}

--- a/fixtures/letta-code/cleanup/expected.json
+++ b/fixtures/letta-code/cleanup/expected.json
@@ -25,6 +25,7 @@
       "role": "tool",
       "tool_call_id": "letta-code-tool-line-5",
       "content": "Error: command failed",
+      "ok": false,
       "timestamp": "2026-07-22T13:00:02.000Z"
     },
     {

--- a/fixtures/letta-code/tool-calls/expected.json
+++ b/fixtures/letta-code/tool-calls/expected.json
@@ -35,6 +35,7 @@
       "role": "tool",
       "tool_call_id": "call-read-1",
       "content": "export const value = 1;",
+      "ok": true,
       "timestamp": "2026-07-22T12:00:02.000Z"
     },
     {

--- a/fixtures/openclaw/cleanup/expected.json
+++ b/fixtures/openclaw/cleanup/expected.json
@@ -27,6 +27,7 @@
       "role": "tool",
       "tool_call_id": "call_oc_err",
       "content": "Error: no image attachment found",
+      "ok": false,
       "timestamp": "2026-07-06T14:00:06.000Z"
     },
     {

--- a/fixtures/openclaw/tool-calls/expected.json
+++ b/fixtures/openclaw/tool-calls/expected.json
@@ -32,6 +32,7 @@
       "role": "tool",
       "tool_call_id": "call_oc_1",
       "content": "README.md\nsrc\n",
+      "ok": true,
       "timestamp": "2026-07-05T09:00:05.500Z"
     },
     {

--- a/fixtures/openhands/tool-calls/expected.json
+++ b/fixtures/openhands/tool-calls/expected.json
@@ -30,6 +30,7 @@
       "role": "tool",
       "tool_call_id": "call_oh_1",
       "content": "/workspace\nready",
+      "ok": true,
       "timestamp": "2026-07-03T10:00:02.000Z"
     },
     {

--- a/fixtures/pi/cleanup/expected.json
+++ b/fixtures/pi/cleanup/expected.json
@@ -27,6 +27,7 @@
       "role": "tool",
       "tool_call_id": "toolu_pi_err",
       "content": "Error: File not found: screenshot.png",
+      "ok": false,
       "timestamp": "2026-07-24T07:00:04.000Z"
     },
     {

--- a/fixtures/pi/tool-calls/expected.json
+++ b/fixtures/pi/tool-calls/expected.json
@@ -32,6 +32,7 @@
       "role": "tool",
       "tool_call_id": "toolu_pi_1",
       "content": "Successfully wrote 46 bytes to notes.txt",
+      "ok": true,
       "timestamp": "2026-07-24T06:21:03.580Z"
     },
     {
@@ -50,6 +51,7 @@
       "role": "tool",
       "tool_call_id": "toolu_pi_2",
       "content": "TODO:\n- collect pi traces\n- write the adapter\n",
+      "ok": true,
       "timestamp": "2026-07-24T06:21:03.640Z"
     },
     {

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -175,7 +175,11 @@ class AssistantToolCallRecord(TypedDict):
     timestamp: str
 
 
-class ToolResultRecord(TypedDict):
+class _ToolResultOptional(TypedDict, total=False):
+    ok: bool
+
+
+class ToolResultRecord(_ToolResultOptional):
     role: Literal["tool"]
     tool_call_id: str
     content: str

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -182,7 +182,7 @@ var claudeCodeAdapter = {
           if (!isObject(block))
             continue;
           if (block.type === "tool_result") {
-            emit(toolResultEvent(blocksText(block.content), typeof block.tool_use_id === "string" ? block.tool_use_id : undefined, line, timestamp));
+            emit(toolResultEvent(blocksText(block.content), typeof block.tool_use_id === "string" ? block.tool_use_id : undefined, typeof block.is_error === "boolean" ? !block.is_error : undefined, line, timestamp));
           } else if (block.type === "text" && typeof block.text === "string") {
             textParts.push(block.text);
           } else if (block.type === "image") {
@@ -277,10 +277,11 @@ function toolCallEvent(id, name, args, inputLine, timestamp, model) {
     ...model ? { model } : {}
   };
 }
-function toolResultEvent(content, callId, inputLine, timestamp) {
+function toolResultEvent(content, callId, ok, inputLine, timestamp) {
   return {
     type: "tool_result",
     content,
+    ...typeof ok === "boolean" ? { ok } : {},
     inputLine,
     ...callId ? { callId } : {},
     ...timestamp ? { timestamp } : {}
@@ -820,6 +821,7 @@ var lettaCodeAdapter = {
         events.push({
           type: "tool_result",
           content,
+          ...typeof row.resultOk === "boolean" ? { ok: row.resultOk } : {},
           inputLine: line,
           ...sourceFields,
           componentIndex: 1,
@@ -948,6 +950,7 @@ function decodePiSessionTranscript(transcript, options) {
       emit({
         type: "tool_result",
         content,
+        ...typeof message.isError === "boolean" ? { ok: !message.isError } : {},
         inputLine: line,
         ...typeof message.toolCallId === "string" && message.toolCallId ? { callId: message.toolCallId } : {},
         ...timestamp ? { timestamp } : {}
@@ -1054,6 +1057,7 @@ var openHandsAdapter = {
       emit({
         type: "tool_result",
         content: result,
+        ...toolResultStatus(event),
         ...callId ? { callId } : {},
         ...timestamp ? { timestamp } : {}
       });
@@ -1104,6 +1108,11 @@ function actionArgsText(event) {
     return jsonString(args);
   }
   return "{}";
+}
+function toolResultStatus(event) {
+  if (event.kind !== "ObservationEvent" || !isObject(event.observation))
+    return {};
+  return typeof event.observation.is_error === "boolean" ? { ok: !event.observation.is_error } : {};
 }
 function extractToolResultText(event) {
   if (event.kind === "ObservationEvent") {
@@ -1233,7 +1242,7 @@ var TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2
 var META_KEYS = new Set(["role", "source", "cwd", "git_branch", "model"]);
 var CONTENT_KEYS = new Set(["role", "content", "timestamp"]);
 var ASSISTANT_TOOL_KEYS = new Set(["role", "content", "timestamp", "tool_calls"]);
-var TOOL_RESULT_KEYS = new Set(["role", "tool_call_id", "content", "timestamp"]);
+var TOOL_RESULT_KEYS = new Set(["role", "tool_call_id", "content", "ok", "timestamp"]);
 var TOOL_CALL_KEYS = new Set(["id", "name", "args"]);
 function validateTranscript(value, options) {
   const partial = options?.partial ?? false;
@@ -1296,6 +1305,9 @@ function validateTranscript(value, options) {
       }
       if (typeof record.content !== "string") {
         fail(`Record ${index}: tool content must be a string.`);
+      }
+      if ("ok" in record && typeof record.ok !== "boolean") {
+        fail(`Record ${index}: tool ok must be boolean when present.`);
       }
       continue;
     }
@@ -1644,7 +1656,8 @@ function normalizeEvent(event, eventIndex, recordIndex, plan, diagnostics, bound
   const record = {
     role: "tool",
     tool_call_id: finalId,
-    content
+    content,
+    ...typeof event.ok === "boolean" ? { ok: event.ok } : {}
   };
   return record;
 }

--- a/schema/trajectory-canonical-v1.schema.json
+++ b/schema/trajectory-canonical-v1.schema.json
@@ -27,6 +27,7 @@
         "tool_name",
         "tool_arguments_json",
         "tool_result_json",
+        "tool_result_ok",
         "record_json"
       ],
       "additionalProperties": false,
@@ -61,6 +62,7 @@
         "tool_name": { "type": ["string", "null"] },
         "tool_arguments_json": { "type": ["string", "null"] },
         "tool_result_json": { "type": ["string", "null"] },
+        "tool_result_ok": { "type": ["boolean", "null"] },
         "record_json": { "type": "string", "minLength": 1 }
       }
     }

--- a/schema/trajectory-v1.schema.json
+++ b/schema/trajectory-v1.schema.json
@@ -91,6 +91,7 @@
         "role": { "const": "tool" },
         "tool_call_id": { "type": "string", "minLength": 1 },
         "content": { "type": "string" },
+        "ok": { "type": "boolean" },
         "timestamp": { "$ref": "#/$defs/timestamp" }
       }
     }

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -131,6 +131,7 @@ export const claudeCodeAdapter: SourceAdapter = {
               toolResultEvent(
                 blocksText(block.content),
                 typeof block.tool_use_id === "string" ? block.tool_use_id : undefined,
+                typeof block.is_error === "boolean" ? !block.is_error : undefined,
                 line,
                 timestamp,
               ),
@@ -315,12 +316,14 @@ function toolCallEvent(
 function toolResultEvent(
   content: string,
   callId: string | undefined,
+  ok: boolean | undefined,
   inputLine: number,
   timestamp?: Date,
 ): DecodedEvent {
   return {
     type: "tool_result",
     content,
+    ...(typeof ok === "boolean" ? { ok } : {}),
     inputLine,
     ...(callId ? { callId } : {}),
     ...(timestamp ? { timestamp } : {}),

--- a/src/adapters/letta-code/index.ts
+++ b/src/adapters/letta-code/index.ts
@@ -135,6 +135,7 @@ export const lettaCodeAdapter: SourceAdapter = {
         events.push({
           type: "tool_result",
           content,
+          ...(typeof row.resultOk === "boolean" ? { ok: row.resultOk } : {}),
           inputLine: line,
           ...sourceFields,
           componentIndex: 1,

--- a/src/adapters/openhands/README.md
+++ b/src/adapters/openhands/README.md
@@ -9,8 +9,9 @@ The adapter decodes `MessageEvent` (user/agent prose), `ActionEvent` (thought
 `oh_<eventId>` fallback), and result events (`ObservationEvent`,
 `AgentErrorEvent`, `UserRejectObservation`). A pre-pass maps action ids to
 call ids so an observation arriving before its action still links instead of
-being dropped as an orphan. OpenHands event `id`s provide native record
-identity.
+being dropped as an orphan. `ObservationEvent.observation.is_error` maps to the
+normalized tool result's `ok` field; other result event kinds remain unknown.
+OpenHands event `id`s provide native record identity.
 
 ## Listing
 

--- a/src/adapters/openhands/index.ts
+++ b/src/adapters/openhands/index.ts
@@ -95,6 +95,7 @@ export const openHandsAdapter: SourceAdapter = {
       emit({
         type: "tool_result",
         content: result,
+        ...toolResultStatus(event),
         ...(callId ? { callId } : {}),
         ...(timestamp ? { timestamp } : {}),
       });
@@ -158,6 +159,13 @@ function actionArgsText(event: Record<string, unknown>): string {
     return jsonString(args);
   }
   return "{}";
+}
+
+function toolResultStatus(event: Record<string, unknown>): { ok?: boolean } {
+  if (event.kind !== "ObservationEvent" || !isObject(event.observation)) return {};
+  return typeof event.observation.is_error === "boolean"
+    ? { ok: !event.observation.is_error }
+    : {};
 }
 
 function extractToolResultText(

--- a/src/adapters/pi-session-shared.ts
+++ b/src/adapters/pi-session-shared.ts
@@ -159,6 +159,7 @@ export function decodePiSessionTranscript(
       emit({
         type: "tool_result",
         content,
+        ...(typeof message.isError === "boolean" ? { ok: !message.isError } : {}),
         inputLine: line,
         ...(typeof message.toolCallId === "string" && message.toolCallId
           ? { callId: message.toolCallId }

--- a/src/canonical.ts
+++ b/src/canonical.ts
@@ -99,6 +99,7 @@ export function buildCanonicalRecords(
       tool_name: flat.toolName,
       tool_arguments_json: flat.toolArgumentsJson,
       tool_result_json: flat.toolResultJson,
+      tool_result_ok: flat.toolResultOk,
       record_json: recordJson,
     };
   });
@@ -244,7 +245,9 @@ function semanticContent(
       return { name: call?.name ?? "", args: call?.args ?? "" };
     }
     case "tool":
-      return { content: record.role === "tool" ? record.content : null };
+      return record.role === "tool"
+        ? { content: record.content, ...(typeof record.ok === "boolean" ? { ok: record.ok } : {}) }
+        : { content: null };
   }
 }
 
@@ -254,6 +257,7 @@ interface FlatFields {
   toolName: string | null;
   toolArgumentsJson: string | null;
   toolResultJson: string | null;
+  toolResultOk: boolean | null;
 }
 
 function flattenFields(
@@ -266,6 +270,7 @@ function flattenFields(
     toolName: null,
     toolArgumentsJson: null,
     toolResultJson: null,
+    toolResultOk: null,
   };
   switch (type) {
     case "user":
@@ -284,7 +289,12 @@ function flattenFields(
     }
     case "tool":
       return record.role === "tool"
-        ? { ...empty, toolCallId: record.tool_call_id, toolResultJson: record.content }
+        ? {
+            ...empty,
+            toolCallId: record.tool_call_id,
+            toolResultJson: record.content,
+            toolResultOk: record.ok ?? null,
+          }
         : empty;
     case "meta":
       return empty;

--- a/src/core.ts
+++ b/src/core.ts
@@ -446,6 +446,7 @@ function normalizeEvent(
     role: "tool",
     tool_call_id: finalId,
     content,
+    ...(typeof event.ok === "boolean" ? { ok: event.ok } : {}),
   };
   return record;
 }

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -62,6 +62,8 @@ export interface DecodedToolResultEvent extends DecodedEventBase {
   type: "tool_result";
   callId?: string;
   content: string;
+  /** Source-native success status when the adapter exposes an authoritative field. */
+  ok?: boolean;
 }
 
 export type DecodedEvent =

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,8 @@ export interface ToolResultRecord {
   role: "tool";
   tool_call_id: string;
   content: string;
+  /** Source-native success status; absent when the source has no authoritative field. */
+  ok?: boolean;
   timestamp: string;
 }
 
@@ -235,6 +237,8 @@ export interface CanonicalRecord {
   tool_name: string | null;
   tool_arguments_json: string | null;
   tool_result_json: string | null;
+  /** Source-native success status for tool results; null when unavailable. */
+  tool_result_ok: boolean | null;
   /** Lossless canonical JSON of the emitted trajectory-v1 record. */
   record_json: string;
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -7,7 +7,7 @@ const TIMESTAMP_PATTERN =
 const META_KEYS = new Set(["role", "source", "cwd", "git_branch", "model"]);
 const CONTENT_KEYS = new Set(["role", "content", "timestamp"]);
 const ASSISTANT_TOOL_KEYS = new Set(["role", "content", "timestamp", "tool_calls"]);
-const TOOL_RESULT_KEYS = new Set(["role", "tool_call_id", "content", "timestamp"]);
+const TOOL_RESULT_KEYS = new Set(["role", "tool_call_id", "content", "ok", "timestamp"]);
 const TOOL_CALL_KEYS = new Set(["id", "name", "args"]);
 
 /**
@@ -94,6 +94,9 @@ export function validateTranscript(
       }
       if (typeof record.content !== "string") {
         fail(`Record ${index}: tool content must be a string.`);
+      }
+      if ("ok" in record && typeof record.ok !== "boolean") {
+        fail(`Record ${index}: tool ok must be boolean when present.`);
       }
       continue;
     }

--- a/src/version.ts
+++ b/src/version.ts
@@ -13,4 +13,4 @@
  */
 export const NORMALIZER_VERSION = "0.2.0";
 
-export const CANONICAL_SCHEMA_VERSION = 1;
+export const CANONICAL_SCHEMA_VERSION = 2;

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -114,9 +114,9 @@ describe("canonical tool result status", () => {
       source: "codex",
       transcript: fixtureText("codex/tool-calls", "input.jsonl"),
     });
-    expect(
-      codex.records.find((record) => record.record_type === "tool")?.tool_result_ok,
-    ).toBeNull();
+    const tool = codex.records.find((record) => record.record_type === "tool");
+    expect(tool).toBeDefined();
+    expect(tool?.tool_result_ok).toBeNull();
   });
 });
 

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -99,6 +99,27 @@ describe("canonical invariants", () => {
   }
 });
 
+describe("canonical tool result status", () => {
+  test("projects source-native status without inferring missing outcomes", () => {
+    const pi = normalizeToCanonical({
+      source: "pi",
+      transcript: fixtureText("pi/cleanup", "input.jsonl"),
+    });
+    const failed = pi.records.find(
+      (record) => record.record_type === "tool" && record.tool_call_id === "toolu_pi_err",
+    );
+    expect(failed?.tool_result_ok).toBe(false);
+
+    const codex = normalizeToCanonical({
+      source: "codex",
+      transcript: fixtureText("codex/tool-calls", "input.jsonl"),
+    });
+    expect(
+      codex.records.find((record) => record.record_type === "tool")?.tool_result_ok,
+    ).toBeNull();
+  });
+});
+
 describe("canonical filtering", () => {
   test("omits tool results and reports the resolved filter", () => {
     const result = normalizeToCanonical({

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -72,7 +72,7 @@ describe("source-native tool result status", () => {
     const tool = result.records.find(
       (record) => record.role === "tool" && record.tool_call_id === "toolu_pi_err",
     );
-    expect(tool?.ok).toBe(false);
+    expect(tool?.role === "tool" ? tool.ok : undefined).toBe(false);
   });
 
   test("maps Claude Code is_error", () => {
@@ -110,7 +110,7 @@ describe("source-native tool result status", () => {
     ].join("\n");
     const result = normalizeTranscript({ source: "claude-code", transcript });
     const tool = result.records.find((record) => record.role === "tool");
-    expect(tool?.ok).toBe(true);
+    expect(tool?.role === "tool" ? tool.ok : undefined).toBe(true);
   });
 
   test("maps Letta Code resultOk", () => {
@@ -119,7 +119,7 @@ describe("source-native tool result status", () => {
       transcript: fixtureText("letta-code/cleanup", "input.jsonl"),
     });
     const tool = result.records.find((record) => record.role === "tool");
-    expect(tool?.ok).toBe(false);
+    expect(tool?.role === "tool" ? tool.ok : undefined).toBe(false);
   });
 
   test("does not infer Codex status from output text", () => {
@@ -128,7 +128,8 @@ describe("source-native tool result status", () => {
       transcript: codexToolTranscript("PASS"),
     });
     const tool = result.records.find((record) => record.role === "tool");
-    expect(tool?.ok).toBeUndefined();
+    expect(tool?.role).toBe("tool");
+    expect(tool?.role === "tool" ? tool.ok : undefined).toBeUndefined();
   });
 });
 

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -63,6 +63,75 @@ describe("golden fixtures", () => {
   }
 });
 
+describe("source-native tool result status", () => {
+  test("maps Pi isError", () => {
+    const result = normalizeTranscript({
+      source: "pi",
+      transcript: fixtureText("pi/cleanup", "input.jsonl"),
+    });
+    const tool = result.records.find(
+      (record) => record.role === "tool" && record.tool_call_id === "toolu_pi_err",
+    );
+    expect(tool?.ok).toBe(false);
+  });
+
+  test("maps Claude Code is_error", () => {
+    const transcript = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "run tests" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "tool_use", id: "call-1", name: "Bash", input: { command: "bun test" } },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: "user",
+        uuid: "u2",
+        message: {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call-1",
+              content: "passed",
+              is_error: false,
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+    const result = normalizeTranscript({ source: "claude-code", transcript });
+    const tool = result.records.find((record) => record.role === "tool");
+    expect(tool?.ok).toBe(true);
+  });
+
+  test("maps Letta Code resultOk", () => {
+    const result = normalizeTranscript({
+      source: "letta-code",
+      transcript: fixtureText("letta-code/cleanup", "input.jsonl"),
+    });
+    const tool = result.records.find((record) => record.role === "tool");
+    expect(tool?.ok).toBe(false);
+  });
+
+  test("does not infer Codex status from output text", () => {
+    const result = normalizeTranscript({
+      source: "codex",
+      transcript: codexToolTranscript("PASS"),
+    });
+    const tool = result.records.find((record) => record.role === "tool");
+    expect(tool?.ok).toBeUndefined();
+  });
+});
+
 describe("public API", () => {
   test("always returns diagnostics", () => {
     const result = normalizeTranscript({


### PR DESCRIPTION
## Summary
- add optional normalized `ToolResultRecord.ok` for authoritative source-native booleans
- map Pi/OpenClaw `isError`, Claude Code `is_error`, Letta Code `resultOk`, and OpenHands observation `is_error`
- add canonical schema v2 `tool_result_ok: boolean | null`
- keep Codex and sources without structured status unknown; never infer from result text
- mirror the optional field in the Python TypedDict and regenerate the bundled CLI/goldens

## Verification
- `bun run check`: 120 passed, 7 skipped, 0 failed; TypeScript typecheck/build passed
- Python wrapper: 10 passed, 1 optional LangGraph SQLite test skipped

## Compatibility
Trajectory v1 is additive: `ok` is optional. Canonical schema advances to v2 because the field set and tool-result semantic hash change.