### PR TITLE
ci: re-enable npm provenance now that the repo is public

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: write
-      # Kept for when provenance / OIDC trusted publishing is enabled; unused
-      # while publishing with NPM_TOKEN (npm rejects --provenance for private
-      # source repos with a 422).
+      # Required for npm provenance attestations (OIDC).
       id-token: write
 
     steps:
@@ -146,10 +144,7 @@ jobs:
             Changes from ${{ steps.version.outputs.old_version }} to ${{ steps.version.outputs.new_version }}
           generate_release_notes: true
 
-      # NOTE: no --provenance while the source repo is private (npm rejects it
-      # with a 422). Once the repo is public, re-add --provenance (or switch to
-      # OIDC trusted publishing like letta-agent-sdk); no other change needed.
       - name: Publish to npm
-        run: npm publish --access public --tag ${{ steps.version.outputs.npm_tag }}
+        run: npm publish --access public --provenance --tag ${{ steps.version.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Repo is public again, so npm provenance can be re-enabled on the release publish path.

## Change
- Re-add `--provenance` to `npm publish` in `.github/workflows/release.yml`
- Keep `id-token: write` (required for OIDC provenance attestations)
- Remove the temporary “private repo / no provenance” comments

## Notes
- Existing published versions (`0.1.0`–`0.2.0`) were published without provenance and stay as-is
- The next `Bump version and release` workflow run will publish a new version with provenance attestations
- No package code changes; CI workflow path only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef8219c9-d9e5-4fb8-a2f5-aacdd3506203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

