### PR TITLE
Add OpenCode transcript adapter

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -154,3 +154,23 @@ A Python-generated fixture was also opened with the official JavaScript
 JavaScript saver rejected Python's `msgpack` serializer type. The production
 adapter therefore delegates to the official Python saver and message reducer
 instead of decoding SQLite blobs or assuming cross-language wire compatibility.
+
+## OpenCode native export
+
+The OpenCode adapter was implemented against the native-format parser in
+`letta-train` and a privacy-safe structural audit of public
+`SALT-NLP/SWE-chat` raw transcripts. The corpus contained 623 `OpenCode` rows
+plus one lowercase `opencode` row. The audit inspected aggregate keys, field
+types, part/status values, and file sizes without retaining transcript content,
+arguments, results, paths, or identifiers.
+
+Native documents consistently used `{info, messages[].parts[]}`. Sampled tool
+states included `completed`, `error`, and one unfinished `running` call. Part
+IDs, call IDs, millisecond times, model, cwd, output, and string errors are
+preserved. Of 17 native documents in the matched sample, 16 normalized
+successfully (5,380 records); one valid but incomplete user-only session
+correctly failed with `missing_assistant_records`.
+
+Sanitized happy-path and cleanup fixtures cover reasoning, linked calls and
+results, terminal status, metadata, unknown semantic records, and canonical
+native identity. No source transcript content was copied into this repository.

--- a/README.md
+++ b/README.md
@@ -79,15 +79,16 @@ and is empty when the transcript required no recoverable cleanup.
 | [`letta-code`](src/adapters/letta-code/) | Letta Code client `transcript.jsonl` | `letta-code` |
 | [`omp`](src/adapters/omp/) | Native OMP (Oh My Pi) coding-agent session JSONL (pi-agent session format) | `omp` |
 | [`openclaw`](src/adapters/openclaw/) | Native OpenClaw session JSONL (pi-agent session format) | `openclaw` |
+| [`opencode`](src/adapters/opencode/) | Native OpenCode `{ "info": ..., "messages": [...] }` session JSON | `opencode` |
 | [`openhands`](src/adapters/openhands/) | JSON event array or an events-API `{ "items": [...] }` envelope | `openhands` |
 | [`pi`](src/adapters/pi/) | Native pi-coding-agent session JSONL | `pi` |
 | [`deepagents`](src/adapters/deepagents/) | Deep Agents CLI LangGraph SQLite store plus `threadId` | `deepagents` |
 
 Tool result records may include `ok: boolean` when the source exposes an
 authoritative structured outcome, such as Pi/OpenClaw `isError`, Claude Code
-`is_error`, Letta Code `resultOk`, or OpenHands observation `is_error`. The
-field is omitted when the source does not expose a reliable status; result text
-is never interpreted as success or failure.
+`is_error`, Letta Code `resultOk`, OpenHands observation `is_error`, or
+OpenCode terminal state. The field is omitted when the source does not expose
+a reliable status; result text is never interpreted as success or failure.
 
 Each adapter lives in its own folder under [`src/adapters/`](src/adapters/)
 with a README documenting the exact input contract, decoding behavior, and
@@ -98,6 +99,8 @@ what the adapter drops.
 `listTrajectories()` enumerates the sessions in a source's standard local
 store, newest first, with cursor pagination. It is a discovery layer beside
 normalization — `normalizeTranscript()` itself never touches the filesystem.
+OpenCode is an export-only input contract and intentionally returns
+`listing_unavailable`; callers locate and read the export themselves.
 
 ```ts
 import { listTrajectories } from "@letta-ai/trajectory";

--- a/fixtures/opencode/cleanup/expected.json
+++ b/fixtures/opencode/cleanup/expected.json
@@ -1,0 +1,45 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "opencode",
+      "cwd": "/workspace/opencode-cleanup",
+      "model": "gpt-test"
+    },
+    {
+      "role": "user",
+      "content": "Read the protected file.",
+      "timestamp": "2026-01-02T00:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "oc-call-error",
+          "name": "read",
+          "args": "{\"path\":\"protected.txt\"}"
+        }
+      ],
+      "timestamp": "2026-01-02T00:00:03.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "oc-call-error",
+      "content": "permission denied",
+      "ok": false,
+      "timestamp": "2026-01-02T00:00:03.500Z"
+    },
+    {
+      "role": "assistant",
+      "content": "The file could not be read.",
+      "timestamp": "2026-01-02T00:00:03.500Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "noise_record_dropped",
+      "message": "Skipped unsupported OpenCode part type \"future-semantic-part\" in message 2."
+    }
+  ]
+}

--- a/fixtures/opencode/cleanup/input.json
+++ b/fixtures/opencode/cleanup/input.json
@@ -1,0 +1,69 @@
+{
+  "info": {
+    "id": "oc-session-cleanup",
+    "directory": "/workspace/opencode-cleanup",
+    "time": {
+      "created": 1767312000000
+    }
+  },
+  "messages": [
+    {
+      "info": {
+        "id": "oc-cleanup-user",
+        "role": "user",
+        "time": {
+          "created": 1767312001000
+        }
+      },
+      "parts": [
+        {
+          "type": "text",
+          "text": "Read the protected file."
+        }
+      ]
+    },
+    {
+      "info": {
+        "id": "oc-cleanup-assistant",
+        "role": "assistant",
+        "modelID": "gpt-test",
+        "time": {
+          "created": 1767312002000
+        }
+      },
+      "parts": [
+        {
+          "type": "step-start"
+        },
+        {
+          "type": "future-semantic-part",
+          "value": "ignored"
+        },
+        {
+          "id": "oc-cleanup-tool",
+          "type": "tool",
+          "callID": "oc-call-error",
+          "tool": "read",
+          "state": {
+            "status": "error",
+            "input": {
+              "path": "protected.txt"
+            },
+            "error": "permission denied",
+            "time": {
+              "start": 1767312003000,
+              "end": 1767312003500
+            }
+          }
+        },
+        {
+          "type": "text",
+          "text": "The file could not be read."
+        },
+        {
+          "type": "step-finish"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/opencode/tool-calls/expected.json
+++ b/fixtures/opencode/tool-calls/expected.json
@@ -1,0 +1,45 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "opencode",
+      "cwd": "/workspace/opencode-demo",
+      "model": "gpt-test"
+    },
+    {
+      "role": "user",
+      "content": "Inspect the project notes.",
+      "timestamp": "2026-01-01T00:00:01.000Z"
+    },
+    {
+      "role": "reasoning",
+      "content": "I should list the note files first.",
+      "timestamp": "2026-01-01T00:00:02.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "oc-call-1",
+          "name": "glob",
+          "args": "{\"pattern\":\"notes/*.md\"}"
+        }
+      ],
+      "timestamp": "2026-01-01T00:00:03.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "oc-call-1",
+      "content": "notes/plan.md",
+      "ok": true,
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "I found the project plan.",
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    }
+  ],
+  "diagnostics": []
+}

--- a/fixtures/opencode/tool-calls/input.json
+++ b/fixtures/opencode/tool-calls/input.json
@@ -1,0 +1,77 @@
+{
+  "info": {
+    "id": "oc-session-1",
+    "directory": "/workspace/opencode-demo",
+    "version": "1.2.21",
+    "time": {
+      "created": 1767225600000
+    }
+  },
+  "messages": [
+    {
+      "info": {
+        "id": "oc-message-user",
+        "role": "user",
+        "sessionID": "oc-session-1",
+        "time": {
+          "created": 1767225601000
+        }
+      },
+      "parts": [
+        {
+          "id": "oc-part-user",
+          "messageID": "oc-message-user",
+          "sessionID": "oc-session-1",
+          "type": "text",
+          "text": "Inspect the project notes."
+        }
+      ]
+    },
+    {
+      "info": {
+        "id": "oc-message-assistant",
+        "role": "assistant",
+        "sessionID": "oc-session-1",
+        "modelID": "gpt-test",
+        "time": {
+          "created": 1767225602000
+        }
+      },
+      "parts": [
+        {
+          "id": "oc-part-reasoning",
+          "messageID": "oc-message-assistant",
+          "sessionID": "oc-session-1",
+          "type": "reasoning",
+          "text": "I should list the note files first."
+        },
+        {
+          "id": "oc-part-tool",
+          "messageID": "oc-message-assistant",
+          "sessionID": "oc-session-1",
+          "type": "tool",
+          "callID": "oc-call-1",
+          "tool": "glob",
+          "state": {
+            "status": "completed",
+            "input": {
+              "pattern": "notes/*.md"
+            },
+            "output": "notes/plan.md",
+            "time": {
+              "start": 1767225603000,
+              "end": 1767225604000
+            }
+          }
+        },
+        {
+          "id": "oc-part-answer",
+          "messageID": "oc-message-assistant",
+          "sessionID": "oc-session-1",
+          "type": "text",
+          "text": "I found the project plan."
+        }
+      ]
+    }
+  ]
+}

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -3,11 +3,11 @@
 from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal[
-    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "openhands", "pi"
+    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
 ]
 CheckpointTrajectorySource = Literal["deepagents"]
 AnyTrajectorySource = Literal[
-    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "openhands", "pi", "deepagents"
+    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 ToolResultPolicy = Literal["include", "omit"]

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -1222,6 +1222,168 @@ function extractToolResultText(event) {
   return;
 }
 
+// src/adapters/opencode/index.ts
+var TRANSPORT_PART_TYPES = new Set([
+  "file",
+  "patch",
+  "snapshot",
+  "step-finish",
+  "step-start",
+  "subtask"
+]);
+var openCodeAdapter = {
+  source: "opencode",
+  decode(transcript) {
+    const document = parseOpenCodeDocument(transcript);
+    const diagnostics = [];
+    const events = [];
+    const sessionInfo = isObject(document.info) ? document.info : {};
+    let partOrdinal = 0;
+    for (let messageIndex = 0;messageIndex < document.messages.length; messageIndex += 1) {
+      const message = document.messages[messageIndex];
+      if (!isObject(message))
+        continue;
+      const info = isObject(message.info) ? message.info : {};
+      const role = info.role;
+      const messageId = nonemptyString2(info.id);
+      const timestamp = parseTimestamp(isObject(info.time) ? info.time.created : undefined);
+      const model = nonemptyString2(info.modelID);
+      const parts = Array.isArray(message.parts) ? message.parts : [];
+      let messageComponentIndex = 0;
+      let latestTimestamp;
+      const orderedTimestamp = (candidate) => {
+        if (!candidate)
+          return latestTimestamp;
+        if (latestTimestamp && candidate.getTime() < latestTimestamp.getTime()) {
+          return latestTimestamp;
+        }
+        latestTimestamp = candidate;
+        return candidate;
+      };
+      for (const part of parts) {
+        const ordinal = partOrdinal++;
+        if (!isObject(part))
+          continue;
+        const partId = nonemptyString2(part.id);
+        const sourceRecordId = partId ?? messageId;
+        let partComponentIndex = 0;
+        const emit = (event) => {
+          const componentIndex = partId ? partComponentIndex++ : messageId ? messageComponentIndex++ : partComponentIndex++;
+          events.push({
+            ...event,
+            ...sourceRecordId ? { sourceRecordId } : { sourceOffset: ordinal, sourceAnchorKind: "ordinal" },
+            sourceSequence: ordinal,
+            componentIndex
+          });
+        };
+        if (part.type === "text") {
+          if (role !== "user" && role !== "assistant")
+            continue;
+          const partTime = isObject(part.time) ? part.time : {};
+          const eventTimestamp = orderedTimestamp(parseTimestamp(partTime.start) ?? timestamp);
+          emit({
+            type: "message",
+            role,
+            content: stringContent(part.text),
+            ...eventTimestamp ? { timestamp: eventTimestamp } : {},
+            ...model ? { model } : {}
+          });
+          continue;
+        }
+        if (part.type === "reasoning") {
+          const partTime = isObject(part.time) ? part.time : {};
+          const eventTimestamp = orderedTimestamp(parseTimestamp(partTime.start) ?? timestamp);
+          emit({
+            type: "reasoning",
+            content: stringContent(part.text),
+            ...eventTimestamp ? { timestamp: eventTimestamp } : {},
+            ...model ? { model } : {}
+          });
+          continue;
+        }
+        if (part.type === "tool") {
+          const state = isObject(part.state) ? part.state : {};
+          const stateTime = isObject(state.time) ? state.time : {};
+          const callTimestamp = orderedTimestamp(parseTimestamp(stateTime.start) ?? timestamp);
+          const resultTimestamp = orderedTimestamp(parseTimestamp(stateTime.end) ?? callTimestamp);
+          const callId = nonemptyString2(part.callID);
+          const name = nonemptyString2(part.tool);
+          emit({
+            type: "tool_call",
+            args: jsonString(state.input),
+            ...callId ? { id: callId } : {},
+            ...name ? { name } : {},
+            ...callTimestamp ? { timestamp: callTimestamp } : {},
+            ...model ? { model } : {}
+          });
+          const status = nonemptyString2(state.status);
+          const output = state.output !== undefined ? stringContent(state.output) : status === "error" ? errorContent(state.error) : undefined;
+          if (output !== undefined) {
+            emit({
+              type: "tool_result",
+              content: output,
+              ...callId ? { callId } : {},
+              ...status === "completed" ? { ok: true } : status === "error" ? { ok: false } : {},
+              ...resultTimestamp ? { timestamp: resultTimestamp } : {},
+              ...model ? { model } : {}
+            });
+          }
+          continue;
+        }
+        if (typeof part.type === "string" && !TRANSPORT_PART_TYPES.has(part.type)) {
+          diagnostics.push({
+            code: "noise_record_dropped",
+            message: `Skipped unsupported OpenCode part type ${JSON.stringify(part.type)} ` + `in message ${messageIndex + 1}.`
+          });
+        }
+      }
+    }
+    const cwd = nonemptyString2(sessionInfo.directory);
+    const sourceGroupId = nonemptyString2(sessionInfo.id);
+    const createdAt = parseTimestamp(isObject(sessionInfo.time) ? sessionInfo.time.created : undefined);
+    return {
+      events,
+      context: {
+        source: "opencode",
+        ...cwd ? { cwd } : {},
+        ...sourceGroupId ? { sourceGroupId } : {},
+        ...createdAt ? { createdAt } : {}
+      },
+      diagnostics
+    };
+  }
+};
+function parseOpenCodeDocument(transcript) {
+  let parsed;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidOpenCodeTranscript();
+  }
+  if (!isObject(parsed) || !isObject(parsed.info) || !Array.isArray(parsed.messages)) {
+    throw invalidOpenCodeTranscript();
+  }
+  return parsed;
+}
+function nonemptyString2(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+function stringContent(value) {
+  if (typeof value === "string")
+    return value;
+  if (value === null || value === undefined)
+    return "";
+  return isObject(value) || Array.isArray(value) ? jsonString(value) : String(value);
+}
+function errorContent(value) {
+  if (isObject(value) && typeof value.message === "string")
+    return value.message;
+  return stringContent(value);
+}
+function invalidOpenCodeTranscript() {
+  return new NormalizationError("invalid_input", "OpenCode transcript must be one JSON document with info and messages arrays of message parts.");
+}
+
 // src/adapters/omp/index.ts
 var ompAdapter = {
   source: "omp",
@@ -2744,7 +2906,7 @@ async function listTrajectories(input) {
   }
   const lister = LISTERS[input.source];
   if (!lister) {
-    throw new NormalizationError("unknown_source", `Unknown trajectory source ${JSON.stringify(input.source)}. Supported sources: ${Object.keys(LISTERS).join(", ")}.`);
+    throw new NormalizationError(input.source === "opencode" ? "listing_unavailable" : "unknown_source", input.source === "opencode" ? `Local trajectory listing is not available for ${JSON.stringify(input.source)}; supply an exported transcript directly to normalizeTranscript().` : `Unknown trajectory source ${JSON.stringify(input.source)}. Supported listing sources: ${Object.keys(LISTERS).join(", ")}.`);
   }
   if (input.root !== undefined && (typeof input.root !== "string" || !input.root)) {
     throw new NormalizationError("invalid_input", "root must be a non-empty string when provided.");
@@ -2806,6 +2968,7 @@ var ADAPTERS = {
   hermes: hermesAdapter,
   "letta-code": lettaCodeAdapter,
   openclaw: openClawAdapter,
+  opencode: openCodeAdapter,
   openhands: openHandsAdapter,
   pi: piAdapter,
   omp: ompAdapter

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -36,6 +36,8 @@ FIXTURES = (
     ("omp", "omp/cleanup", "input.jsonl"),
     ("openclaw", "openclaw/tool-calls", "input.jsonl"),
     ("openclaw", "openclaw/cleanup", "input.jsonl"),
+    ("opencode", "opencode/tool-calls", "input.json"),
+    ("opencode", "opencode/cleanup", "input.json"),
     ("openhands", "openhands/tool-calls", "input.json"),
     ("openhands", "openhands/cleanup", "input.json"),
     ("pi", "pi/tool-calls", "input.jsonl"),

--- a/src/adapters/opencode/README.md
+++ b/src/adapters/opencode/README.md
@@ -1,0 +1,37 @@
+# opencode
+
+The adapter accepts one native OpenCode session export as a single JSON
+document:
+
+```json
+{ "info": { "...": "..." }, "messages": [{ "info": {}, "parts": [] }] }
+```
+
+This is a whole document even when a corpus stores it with a `.jsonl`
+extension. `info.id`, `info.directory`, and `info.time.created` provide the
+session identity, working directory, and creation time. Message metadata
+provides role, model, and message time.
+
+Message parts decode as follows:
+
+- `text` becomes user or assistant prose.
+- `reasoning` becomes a reasoning record.
+- `tool` becomes one call and, when the state is terminal, its linked result.
+  `callID` and `tool` are preserved; `state.input` is serialized as arguments;
+  `state.output` or `state.error` supplies result content.
+- `completed` and `error` states map to `ok: true` and `ok: false`.
+  A `running` call without output remains an unfinished call.
+
+Native part IDs are the preferred canonical source identity. Older or
+hand-built exports fall back to message IDs and then whole-document part
+ordinals. Part timestamps take precedence over message timestamps; a later
+part without its own time inherits the latest time in that message so the
+native part order remains stable.
+
+`step-start`, `step-finish`, `patch`, `snapshot`, `file`, and `subtask` parts
+are transport/state records and are dropped. Other unknown part types are
+dropped with a diagnostic.
+
+Local-store discovery is intentionally not provided. The caller supplies an
+already assembled OpenCode session export to
+`normalizeTranscript({ source: "opencode", transcript })`.

--- a/src/adapters/opencode/index.ts
+++ b/src/adapters/opencode/index.ts
@@ -1,0 +1,228 @@
+import type {
+  DecodedEvent,
+  DecodedSession,
+  SourceAdapter,
+} from "../../internal.js";
+import type { Diagnostic } from "../../types.js";
+import { NormalizationError } from "../../types.js";
+import {
+  isObject,
+  jsonString,
+  parseTimestamp,
+} from "../shared.js";
+
+const TRANSPORT_PART_TYPES = new Set([
+  "file",
+  "patch",
+  "snapshot",
+  "step-finish",
+  "step-start",
+  "subtask",
+]);
+
+/**
+ * Decode an OpenCode whole-session export: `{ info, messages[].parts[] }`.
+ * Despite the `.jsonl` suffix used by some corpora, this is one JSON document.
+ */
+export const openCodeAdapter: SourceAdapter = {
+  source: "opencode",
+
+  decode(transcript: string): DecodedSession {
+    const document = parseOpenCodeDocument(transcript);
+    const diagnostics: Diagnostic[] = [];
+    const events: DecodedEvent[] = [];
+    const sessionInfo = isObject(document.info) ? document.info : {};
+    let partOrdinal = 0;
+
+    for (let messageIndex = 0; messageIndex < document.messages.length; messageIndex += 1) {
+      const message = document.messages[messageIndex];
+      if (!isObject(message)) continue;
+      const info = isObject(message.info) ? message.info : {};
+      const role = info.role;
+      const messageId = nonemptyString(info.id);
+      const timestamp = parseTimestamp(
+        isObject(info.time) ? info.time.created : undefined,
+      );
+      const model = nonemptyString(info.modelID);
+      const parts = Array.isArray(message.parts) ? message.parts : [];
+      let messageComponentIndex = 0;
+      let latestTimestamp: Date | undefined;
+      const orderedTimestamp = (candidate: Date | undefined): Date | undefined => {
+        if (!candidate) return latestTimestamp;
+        if (latestTimestamp && candidate.getTime() < latestTimestamp.getTime()) {
+          return latestTimestamp;
+        }
+        latestTimestamp = candidate;
+        return candidate;
+      };
+
+      for (const part of parts) {
+        const ordinal = partOrdinal++;
+        if (!isObject(part)) continue;
+        const partId = nonemptyString(part.id);
+        const sourceRecordId = partId ?? messageId;
+        let partComponentIndex = 0;
+        const emit = (event: DecodedEvent): void => {
+          const componentIndex = partId
+            ? partComponentIndex++
+            : messageId
+              ? messageComponentIndex++
+              : partComponentIndex++;
+          events.push({
+            ...event,
+            ...(sourceRecordId
+              ? { sourceRecordId }
+              : { sourceOffset: ordinal, sourceAnchorKind: "ordinal" }),
+            sourceSequence: ordinal,
+            componentIndex,
+          });
+        };
+
+        if (part.type === "text") {
+          if (role !== "user" && role !== "assistant") continue;
+          const partTime = isObject(part.time) ? part.time : {};
+          const eventTimestamp = orderedTimestamp(
+            parseTimestamp(partTime.start) ?? timestamp,
+          );
+          emit({
+            type: "message",
+            role,
+            content: stringContent(part.text),
+            ...(eventTimestamp ? { timestamp: eventTimestamp } : {}),
+            ...(model ? { model } : {}),
+          });
+          continue;
+        }
+
+        if (part.type === "reasoning") {
+          const partTime = isObject(part.time) ? part.time : {};
+          const eventTimestamp = orderedTimestamp(
+            parseTimestamp(partTime.start) ?? timestamp,
+          );
+          emit({
+            type: "reasoning",
+            content: stringContent(part.text),
+            ...(eventTimestamp ? { timestamp: eventTimestamp } : {}),
+            ...(model ? { model } : {}),
+          });
+          continue;
+        }
+
+        if (part.type === "tool") {
+          const state = isObject(part.state) ? part.state : {};
+          const stateTime = isObject(state.time) ? state.time : {};
+          const callTimestamp = orderedTimestamp(
+            parseTimestamp(stateTime.start) ?? timestamp,
+          );
+          const resultTimestamp = orderedTimestamp(
+            parseTimestamp(stateTime.end) ?? callTimestamp,
+          );
+          const callId = nonemptyString(part.callID);
+          const name = nonemptyString(part.tool);
+          emit({
+            type: "tool_call",
+            args: jsonString(state.input),
+            ...(callId ? { id: callId } : {}),
+            ...(name ? { name } : {}),
+            ...(callTimestamp ? { timestamp: callTimestamp } : {}),
+            ...(model ? { model } : {}),
+          });
+
+          const status = nonemptyString(state.status);
+          const output =
+            state.output !== undefined
+              ? stringContent(state.output)
+              : status === "error"
+                ? errorContent(state.error)
+                : undefined;
+          if (output !== undefined) {
+            emit({
+              type: "tool_result",
+              content: output,
+              ...(callId ? { callId } : {}),
+              ...(status === "completed"
+                ? { ok: true }
+                : status === "error"
+                  ? { ok: false }
+                  : {}),
+              ...(resultTimestamp ? { timestamp: resultTimestamp } : {}),
+              ...(model ? { model } : {}),
+            });
+          }
+          continue;
+        }
+
+        if (
+          typeof part.type === "string" &&
+          !TRANSPORT_PART_TYPES.has(part.type)
+        ) {
+          diagnostics.push({
+            code: "noise_record_dropped",
+            message:
+              `Skipped unsupported OpenCode part type ${JSON.stringify(part.type)} ` +
+              `in message ${messageIndex + 1}.`,
+          });
+        }
+      }
+    }
+
+    const cwd = nonemptyString(sessionInfo.directory);
+    const sourceGroupId = nonemptyString(sessionInfo.id);
+    const createdAt = parseTimestamp(
+      isObject(sessionInfo.time) ? sessionInfo.time.created : undefined,
+    );
+    return {
+      events,
+      context: {
+        source: "opencode",
+        ...(cwd ? { cwd } : {}),
+        ...(sourceGroupId ? { sourceGroupId } : {}),
+        ...(createdAt ? { createdAt } : {}),
+      },
+      diagnostics,
+    };
+  },
+};
+
+interface OpenCodeDocument extends Record<string, unknown> {
+  messages: unknown[];
+}
+
+function parseOpenCodeDocument(transcript: string): OpenCodeDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidOpenCodeTranscript();
+  }
+  if (
+    !isObject(parsed) ||
+    !isObject(parsed.info) ||
+    !Array.isArray(parsed.messages)
+  ) {
+    throw invalidOpenCodeTranscript();
+  }
+  return parsed as OpenCodeDocument;
+}
+
+function nonemptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function stringContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  return isObject(value) || Array.isArray(value) ? jsonString(value) : String(value);
+}
+
+function errorContent(value: unknown): string {
+  if (isObject(value) && typeof value.message === "string") return value.message;
+  return stringContent(value);
+}
+
+function invalidOpenCodeTranscript(): NormalizationError {
+  return new NormalizationError(
+    "invalid_input",
+    "OpenCode transcript must be one JSON document with info and messages arrays of message parts.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { hermesAdapter } from "./adapters/hermes/index.js";
 import { lettaCodeAdapter } from "./adapters/letta-code/index.js";
 import { openClawAdapter } from "./adapters/openclaw/index.js";
 import { openHandsAdapter } from "./adapters/openhands/index.js";
+import { openCodeAdapter } from "./adapters/opencode/index.js";
 import { ompAdapter } from "./adapters/omp/index.js";
 import { piAdapter } from "./adapters/pi/index.js";
 import type { ResolvedNormalizationBounds } from "./bounds.js";
@@ -32,6 +33,7 @@ const ADAPTERS: Record<TranscriptTrajectorySource, SourceAdapter> = {
   hermes: hermesAdapter,
   "letta-code": lettaCodeAdapter,
   openclaw: openClawAdapter,
+  opencode: openCodeAdapter,
   openhands: openHandsAdapter,
   pi: piAdapter,
   omp: ompAdapter,

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -60,7 +60,7 @@ export interface ListTrajectoriesResult {
 
 type SourceLister = (root: string | undefined) => Promise<TrajectoryListing[]>;
 
-const LISTERS: Record<AnyTrajectorySource, SourceLister> = {
+const LISTERS: Partial<Record<AnyTrajectorySource, SourceLister>> = {
   "claude-code": listClaudeCodeTrajectories,
   codex: listCodexTrajectories,
   droid: listDroidTrajectories,
@@ -87,8 +87,10 @@ export async function listTrajectories(
   const lister = LISTERS[input.source];
   if (!lister) {
     throw new NormalizationError(
-      "unknown_source",
-      `Unknown trajectory source ${JSON.stringify(input.source)}. Supported sources: ${Object.keys(LISTERS).join(", ")}.`,
+      input.source === "opencode" ? "listing_unavailable" : "unknown_source",
+      input.source === "opencode"
+        ? `Local trajectory listing is not available for ${JSON.stringify(input.source)}; supply an exported transcript directly to normalizeTranscript().`
+        : `Unknown trajectory source ${JSON.stringify(input.source)}. Supported listing sources: ${Object.keys(LISTERS).join(", ")}.`,
     );
   }
   if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export type TrajectorySource =
   | "letta-code"
   | "omp"
   | "openclaw"
+  | "opencode"
   | "openhands"
   | "pi";
 

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -40,6 +40,13 @@ const goldenFixtures = [
   golden: string;
 }>;
 
+const additionalInvariantFixtures = [
+  { source: "opencode", name: "opencode/tool-calls" },
+] as const satisfies ReadonlyArray<{
+  source: TrajectorySource;
+  name: string;
+}>;
+
 describe("canonical golden fixtures", () => {
   for (const fixture of goldenFixtures) {
     test(fixture.name, () => {
@@ -66,10 +73,12 @@ describe("canonical golden fixtures", () => {
 });
 
 describe("canonical invariants", () => {
-  for (const fixture of goldenFixtures) {
+  for (const fixture of [...goldenFixtures, ...additionalInvariantFixtures]) {
     test(fixture.name, () => {
       const inputFile =
-        fixture.source === "openhands" || fixture.source === "hermes"
+        fixture.source === "openhands" ||
+        fixture.source === "hermes" ||
+        fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl";
       const result = normalizeToCanonical({
@@ -98,6 +107,20 @@ describe("canonical invariants", () => {
       expect([...orderKeys]).toEqual([...orderKeys].sort());
     });
   }
+});
+
+describe("OpenCode source-native identity", () => {
+  test("uses native part and message ids", () => {
+    const result = normalizeToCanonical({
+      source: "opencode",
+      transcript: fixtureText("opencode/tool-calls", "input.json"),
+    });
+    const body = result.records.filter((record) => record.record_type !== "meta");
+    expect(body.length).toBeGreaterThan(0);
+    expect(body.every((record) => record.source_identity_kind === "native")).toBe(
+      true,
+    );
+  });
 });
 
 describe("canonical tool result status", () => {

--- a/test/listing.test.ts
+++ b/test/listing.test.ts
@@ -126,6 +126,12 @@ afterAll(() => {
 });
 
 describe("listTrajectories", () => {
+  test("reports normalization-only sources without pretending to discover a store", async () => {
+    await expect(listTrajectories({ source: "opencode" })).rejects.toEqual(
+      expect.objectContaining({ code: "listing_unavailable" }),
+    );
+  });
+
   test("lists claude-code parent and subagent sessions newest first", async () => {
     const result = await listTrajectories({
       source: "claude-code",

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -25,6 +25,8 @@ const fixtures = [
   { source: "omp", name: "omp/cleanup" },
   { source: "openclaw", name: "openclaw/tool-calls" },
   { source: "openclaw", name: "openclaw/cleanup" },
+  { source: "opencode", name: "opencode/tool-calls" },
+  { source: "opencode", name: "opencode/cleanup" },
   { source: "openhands", name: "openhands/tool-calls" },
   { source: "openhands", name: "openhands/cleanup" },
   { source: "pi", name: "pi/tool-calls" },
@@ -48,7 +50,9 @@ describe("golden fixtures", () => {
     test(fixture.name, () => {
       const input = fixtureText(
         fixture.name,
-        fixture.source === "openhands" || fixture.source === "hermes"
+        fixture.source === "openhands" ||
+          fixture.source === "hermes" ||
+          fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl",
       );
@@ -345,6 +349,15 @@ describe("public API", () => {
     ).toThrow(expect.objectContaining({ code: "invalid_input" }));
   });
 
+  test("rejects an invalid opencode document shape", () => {
+    expect(() =>
+      normalizeTranscript({
+        source: "opencode",
+        transcript: "{}",
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
   test("rejects Letta API message arrays", () => {
     expect(() =>
       normalizeTranscript({
@@ -393,7 +406,9 @@ describe("public API", () => {
     test(`omits tool results while retaining calls for ${fixture.source}`, () => {
       const input = fixtureText(
         fixture.name,
-        fixture.source === "openhands" || fixture.source === "hermes"
+        fixture.source === "openhands" ||
+          fixture.source === "hermes" ||
+          fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl",
       );


### PR DESCRIPTION
## Summary

- normalize native OpenCode whole-session exports with text, reasoning, tool calls/results, metadata, and terminal status
- preserve native part/message identity for canonical normalization
- add sanitized fixtures, TypeScript/Python parity coverage, and adapter contract documentation
- report `listing_unavailable` because this adapter accepts supplied exports rather than owning local-store discovery

## Stack

The CI/Python parity prerequisite landed in #31. This is now the first adapter PR in the stack.

## Testing

- `bun run check` (139 passed, 7 optional-dependency skips)
- `PYTHONPATH="$PWD/python/src" python3.12 -m unittest discover -s python/tests -v` (11 passed, 1 optional-dependency skip)
- `git diff --check`