### PR TITLE
Add Gemini CLI transcript adapter

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -174,3 +174,21 @@ correctly failed with `missing_assistant_records`.
 Sanitized happy-path and cleanup fixtures cover reasoning, linked calls and
 results, terminal status, metadata, unknown semantic records, and canonical
 native identity. No source transcript content was copied into this repository.
+
+## Gemini CLI native export
+
+The Gemini CLI adapter was checked against a privacy-safe structural audit of
+the public `SALT-NLP/SWE-chat` raw transcripts and the native-format parser in
+`letta-train`. The corpus contained 59 `Gemini CLI` rows, although agent labels
+were not reliable wire-format identifiers: some labelled files used another
+supported capture shape and must be routed by content.
+
+Native documents used `{sessionId, projectHash, messages[]}`. Sampled terminal
+tool statuses were `success`, `error`, and `cancelled`; results used inline
+`functionResponse.response` objects. All 15 native documents in the matched
+sample normalized successfully (4,932 records).
+
+Sanitized happy-path and cleanup fixtures cover thoughts, prose, linked inline
+tool responses, structured status, unsupported message diagnostics, metadata,
+and canonical native identity. The audit retained no transcript content,
+arguments, results, paths, or identifiers.

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ and is empty when the transcript required no recoverable cleanup.
 | [`claude-code`](src/adapters/claude-code/) | Native Claude Code JSONL | `claude-code` |
 | [`codex`](src/adapters/codex/) | Native Codex rollout JSONL | `codex` |
 | [`droid`](src/adapters/droid/) | Native Droid session JSONL | `droid` |
+| [`gemini-cli`](src/adapters/gemini-cli/) | Native Gemini CLI whole-session JSON | `gemini-cli` |
 | [`hermes`](src/adapters/hermes/) | Session-store message-row array or a `{ "session": {...}, "messages": [...] }` envelope | `hermes` |
 | [`letta-code`](src/adapters/letta-code/) | Letta Code client `transcript.jsonl` | `letta-code` |
 | [`omp`](src/adapters/omp/) | Native OMP (Oh My Pi) coding-agent session JSONL (pi-agent session format) | `omp` |
@@ -87,8 +88,9 @@ and is empty when the transcript required no recoverable cleanup.
 Tool result records may include `ok: boolean` when the source exposes an
 authoritative structured outcome, such as Pi/OpenClaw `isError`, Claude Code
 `is_error`, Letta Code `resultOk`, OpenHands observation `is_error`, or
-OpenCode terminal state. The field is omitted when the source does not expose
-a reliable status; result text is never interpreted as success or failure.
+OpenCode/Gemini terminal state. The field is omitted when the source does not
+expose a reliable status; result text is never interpreted as success or
+failure.
 
 Each adapter lives in its own folder under [`src/adapters/`](src/adapters/)
 with a README documenting the exact input contract, decoding behavior, and
@@ -99,8 +101,8 @@ what the adapter drops.
 `listTrajectories()` enumerates the sessions in a source's standard local
 store, newest first, with cursor pagination. It is a discovery layer beside
 normalization — `normalizeTranscript()` itself never touches the filesystem.
-OpenCode is an export-only input contract and intentionally returns
-`listing_unavailable`; callers locate and read the export themselves.
+Gemini CLI and OpenCode are export-only input contracts and intentionally
+return `listing_unavailable`; callers locate and read the exports themselves.
 
 ```ts
 import { listTrajectories } from "@letta-ai/trajectory";

--- a/fixtures/gemini-cli/cleanup/expected.json
+++ b/fixtures/gemini-cli/cleanup/expected.json
@@ -1,0 +1,39 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "gemini-cli",
+      "model": "gemini-test"
+    },
+    {
+      "role": "user",
+      "content": "Read the missing file.",
+      "timestamp": "2026-01-04T00:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "gemini-call-error",
+          "name": "read_file",
+          "args": "{\"file_path\":\"missing.txt\"}"
+        }
+      ],
+      "timestamp": "2026-01-04T00:00:03.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "gemini-call-error",
+      "content": "{\"error\":\"file missing\"}",
+      "ok": false,
+      "timestamp": "2026-01-04T00:00:03.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "noise_record_dropped",
+      "message": "Skipped unsupported Gemini CLI message type \"telemetry\" at position 1."
+    }
+  ]
+}

--- a/fixtures/gemini-cli/cleanup/input.json
+++ b/fixtures/gemini-cli/cleanup/input.json
@@ -1,0 +1,49 @@
+{
+  "sessionId": "gemini-session-cleanup",
+  "projectHash": "project-hash",
+  "startTime": "2026-01-04T00:00:00.000Z",
+  "messages": [
+    {
+      "id": "gemini-unknown",
+      "type": "telemetry",
+      "timestamp": "2026-01-04T00:00:00.000Z",
+      "content": "ignored"
+    },
+    {
+      "id": "gemini-cleanup-user",
+      "type": "user",
+      "timestamp": "2026-01-04T00:00:01.000Z",
+      "content": "Read the missing file."
+    },
+    {
+      "id": "gemini-cleanup-assistant",
+      "type": "gemini",
+      "timestamp": "2026-01-04T00:00:02.000Z",
+      "model": "gemini-test",
+      "thoughts": [],
+      "content": "",
+      "toolCalls": [
+        {
+          "id": "gemini-call-error",
+          "name": "read_file",
+          "args": {
+            "file_path": "missing.txt"
+          },
+          "result": [
+            {
+              "functionResponse": {
+                "id": "gemini-call-error",
+                "name": "read_file",
+                "response": {
+                  "error": "file missing"
+                }
+              }
+            }
+          ],
+          "status": "error",
+          "timestamp": "2026-01-04T00:00:03.000Z"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/gemini-cli/tool-calls/expected.json
+++ b/fixtures/gemini-cli/tool-calls/expected.json
@@ -1,0 +1,44 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "gemini-cli",
+      "model": "gemini-test"
+    },
+    {
+      "role": "user",
+      "content": "Read the project overview.",
+      "timestamp": "2026-01-03T00:00:01.000Z"
+    },
+    {
+      "role": "reasoning",
+      "content": "Planning — read the overview first",
+      "timestamp": "2026-01-03T00:00:02.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "I will inspect the overview.",
+      "timestamp": "2026-01-03T00:00:02.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "gemini-call-1",
+          "name": "read_file",
+          "args": "{\"file_path\":\"OVERVIEW.md\"}"
+        }
+      ],
+      "timestamp": "2026-01-03T00:00:03.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "gemini-call-1",
+      "content": "Project overview",
+      "ok": true,
+      "timestamp": "2026-01-03T00:00:03.000Z"
+    }
+  ],
+  "diagnostics": []
+}

--- a/fixtures/gemini-cli/tool-calls/input.json
+++ b/fixtures/gemini-cli/tool-calls/input.json
@@ -1,0 +1,59 @@
+{
+  "sessionId": "gemini-session-1",
+  "projectHash": "project-hash",
+  "startTime": "2026-01-03T00:00:00.000Z",
+  "lastUpdated": "2026-01-03T00:00:04.000Z",
+  "messages": [
+    {
+      "id": "gemini-info",
+      "type": "info",
+      "timestamp": "2026-01-03T00:00:00.000Z",
+      "content": "Harness notice"
+    },
+    {
+      "id": "gemini-user",
+      "type": "user",
+      "timestamp": "2026-01-03T00:00:01.000Z",
+      "content": [
+        {
+          "text": "Read the project overview."
+        }
+      ]
+    },
+    {
+      "id": "gemini-assistant",
+      "type": "gemini",
+      "timestamp": "2026-01-03T00:00:02.000Z",
+      "model": "gemini-test",
+      "thoughts": [
+        {
+          "subject": "Planning",
+          "description": "read the overview first"
+        }
+      ],
+      "content": "I will inspect the overview.",
+      "toolCalls": [
+        {
+          "id": "gemini-call-1",
+          "name": "read_file",
+          "args": {
+            "file_path": "OVERVIEW.md"
+          },
+          "result": [
+            {
+              "functionResponse": {
+                "id": "gemini-call-1",
+                "name": "read_file",
+                "response": {
+                  "output": "Project overview"
+                }
+              }
+            }
+          ],
+          "status": "success",
+          "timestamp": "2026-01-03T00:00:03.000Z"
+        }
+      ]
+    }
+  ]
+}

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -3,11 +3,11 @@
 from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal[
-    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
+    "claude-code", "codex", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
 ]
 CheckpointTrajectorySource = Literal["deepagents"]
 AnyTrajectorySource = Literal[
-    "claude-code", "codex", "droid", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
+    "claude-code", "codex", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 ToolResultPolicy = Literal["include", "omit"]

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -561,6 +561,166 @@ function toolResultContent(content, isError) {
   return isError && !/^error/i.test(text) ? `Error: ${text}` : text;
 }
 
+// src/adapters/gemini-cli/index.ts
+var TERMINAL_TOOL_STATUSES = new Set(["cancelled", "error", "success"]);
+var geminiCliAdapter = {
+  source: "gemini-cli",
+  decode(transcript) {
+    const document = parseGeminiDocument(transcript);
+    const diagnostics = [];
+    const events = [];
+    for (let messageIndex = 0;messageIndex < document.messages.length; messageIndex += 1) {
+      const message = document.messages[messageIndex];
+      if (!isObject(message))
+        continue;
+      const messageType = message.type;
+      if (messageType === "info")
+        continue;
+      const timestamp = parseTimestamp(message.timestamp);
+      const model = nonemptyString(message.model);
+      const sourceRecordId = nonemptyString(message.id);
+      let componentIndex = 0;
+      const emit = (event) => {
+        events.push({
+          ...event,
+          ...sourceRecordId ? { sourceRecordId } : { sourceOffset: messageIndex, sourceAnchorKind: "ordinal" },
+          sourceSequence: messageIndex,
+          componentIndex: componentIndex++
+        });
+      };
+      if (messageType === "user") {
+        emit({
+          type: "message",
+          role: "user",
+          content: blocksText(message.content),
+          ...timestamp ? { timestamp } : {}
+        });
+        continue;
+      }
+      if (messageType !== "gemini") {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message: `Skipped unsupported Gemini CLI message type ${JSON.stringify(messageType)} ` + `at position ${messageIndex + 1}.`
+        });
+        continue;
+      }
+      if (Array.isArray(message.thoughts)) {
+        for (const thought of message.thoughts) {
+          const content2 = thoughtContent(thought);
+          if (!content2.trim())
+            continue;
+          emit({
+            type: "reasoning",
+            content: content2,
+            ...timestamp ? { timestamp } : {},
+            ...model ? { model } : {}
+          });
+        }
+      }
+      const content = blocksText(message.content);
+      if (content.trim()) {
+        emit({
+          type: "message",
+          role: "assistant",
+          content,
+          ...timestamp ? { timestamp } : {},
+          ...model ? { model } : {}
+        });
+      }
+      if (!Array.isArray(message.toolCalls))
+        continue;
+      for (const rawCall of message.toolCalls) {
+        if (!isObject(rawCall))
+          continue;
+        const callId = nonemptyString(rawCall.id);
+        const name = nonemptyString(rawCall.name);
+        const callTimestamp = parseTimestamp(rawCall.timestamp) ?? timestamp;
+        emit({
+          type: "tool_call",
+          args: jsonString(rawCall.args),
+          ...callId ? { id: callId } : {},
+          ...name ? { name } : {},
+          ...callTimestamp ? { timestamp: callTimestamp } : {},
+          ...model ? { model } : {}
+        });
+        const status = nonemptyString(rawCall.status);
+        const outputs = toolOutputs(rawCall.result);
+        if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
+          continue;
+        }
+        emit({
+          type: "tool_result",
+          content: outputs.join(`
+`),
+          ...callId ? { callId } : {},
+          ...status === "success" ? { ok: true } : status === "error" || status === "cancelled" ? { ok: false } : {},
+          ...callTimestamp ? { timestamp: callTimestamp } : {},
+          ...model ? { model } : {}
+        });
+      }
+    }
+    const sourceGroupId = nonemptyString(document.sessionId);
+    const createdAt = parseTimestamp(document.startTime);
+    return {
+      events,
+      context: {
+        source: "gemini-cli",
+        ...sourceGroupId ? { sourceGroupId } : {},
+        ...createdAt ? { createdAt } : {}
+      },
+      diagnostics
+    };
+  }
+};
+function parseGeminiDocument(transcript) {
+  let parsed;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidGeminiTranscript();
+  }
+  if (!isObject(parsed) || !Array.isArray(parsed.messages) || typeof parsed.sessionId !== "string" && typeof parsed.projectHash !== "string") {
+    throw invalidGeminiTranscript();
+  }
+  return parsed;
+}
+function nonemptyString(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+function thoughtContent(value) {
+  if (!isObject(value))
+    return String(value ?? "");
+  return ["subject", "description"].flatMap((key) => typeof value[key] === "string" && value[key] ? [value[key]] : []).join(" — ");
+}
+function toolOutputs(value) {
+  if (!Array.isArray(value))
+    return [];
+  const outputs = [];
+  for (const item of value) {
+    if (!isObject(item) || !isObject(item.functionResponse))
+      continue;
+    const response = item.functionResponse.response;
+    if (!isObject(response))
+      continue;
+    if (response.output !== undefined) {
+      outputs.push(stringContent(response.output));
+    } else if (Object.keys(response).length > 0) {
+      outputs.push(jsonString(response));
+    }
+  }
+  return outputs;
+}
+function stringContent(value) {
+  if (typeof value === "string")
+    return value;
+  if (value === null || value === undefined)
+    return "";
+  return isObject(value) || Array.isArray(value) ? jsonString(value) : String(value);
+}
+function invalidGeminiTranscript() {
+  return new NormalizationError("invalid_input", "Gemini CLI transcript must be one native session JSON document with " + "session metadata and a messages array.");
+}
+
 // src/adapters/hermes/index.ts
 var CONTENT_JSON_PREFIX = "\x00json:";
 var hermesAdapter = {
@@ -833,7 +993,7 @@ var lettaCodeAdapter = {
     for (const { value: row } of rows) {
       if (row.kind !== "reasoning")
         continue;
-      const sourceRecordId = nonemptyString(row.source_message_id) ?? nonemptyString(row.source_line_id);
+      const sourceRecordId = nonemptyString2(row.source_message_id) ?? nonemptyString2(row.source_line_id);
       if (sourceRecordId)
         reasoningRecordIds.add(sourceRecordId);
     }
@@ -856,8 +1016,8 @@ var lettaCodeAdapter = {
         continue;
       }
       const timestamp = parseTimestamp(row.captured_at);
-      const sourceMessageId = nonemptyString(row.source_message_id);
-      const sourceLineId = nonemptyString(row.source_line_id);
+      const sourceMessageId = nonemptyString2(row.source_message_id);
+      const sourceLineId = nonemptyString2(row.source_line_id);
       const sourceRecordId = sourceMessageId ?? sourceLineId;
       const sourceFields = sourceRecordId ? { sourceRecordId } : {
         sourceOffset: line - 1,
@@ -896,10 +1056,10 @@ var lettaCodeAdapter = {
         continue;
       }
       const callId = sourceLineId ?? sourceMessageId ?? `letta-code-tool-line-${line}`;
-      const name = nonemptyString(row.name);
+      const name = nonemptyString2(row.name);
       events.push({
         type: "tool_call",
-        args: nonemptyString(row.argsText) ?? "{}",
+        args: nonemptyString2(row.argsText) ?? "{}",
         inputLine: line,
         ...sourceFields,
         componentIndex: 0,
@@ -934,7 +1094,7 @@ var lettaCodeAdapter = {
     };
   }
 };
-function nonemptyString(value) {
+function nonemptyString2(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function invalidLettaCodeTranscript() {
@@ -1245,9 +1405,9 @@ var openCodeAdapter = {
         continue;
       const info = isObject(message.info) ? message.info : {};
       const role = info.role;
-      const messageId = nonemptyString2(info.id);
+      const messageId = nonemptyString3(info.id);
       const timestamp = parseTimestamp(isObject(info.time) ? info.time.created : undefined);
-      const model = nonemptyString2(info.modelID);
+      const model = nonemptyString3(info.modelID);
       const parts = Array.isArray(message.parts) ? message.parts : [];
       let messageComponentIndex = 0;
       let latestTimestamp;
@@ -1264,7 +1424,7 @@ var openCodeAdapter = {
         const ordinal = partOrdinal++;
         if (!isObject(part))
           continue;
-        const partId = nonemptyString2(part.id);
+        const partId = nonemptyString3(part.id);
         const sourceRecordId = partId ?? messageId;
         let partComponentIndex = 0;
         const emit = (event) => {
@@ -1284,7 +1444,7 @@ var openCodeAdapter = {
           emit({
             type: "message",
             role,
-            content: stringContent(part.text),
+            content: stringContent2(part.text),
             ...eventTimestamp ? { timestamp: eventTimestamp } : {},
             ...model ? { model } : {}
           });
@@ -1295,7 +1455,7 @@ var openCodeAdapter = {
           const eventTimestamp = orderedTimestamp(parseTimestamp(partTime.start) ?? timestamp);
           emit({
             type: "reasoning",
-            content: stringContent(part.text),
+            content: stringContent2(part.text),
             ...eventTimestamp ? { timestamp: eventTimestamp } : {},
             ...model ? { model } : {}
           });
@@ -1306,8 +1466,8 @@ var openCodeAdapter = {
           const stateTime = isObject(state.time) ? state.time : {};
           const callTimestamp = orderedTimestamp(parseTimestamp(stateTime.start) ?? timestamp);
           const resultTimestamp = orderedTimestamp(parseTimestamp(stateTime.end) ?? callTimestamp);
-          const callId = nonemptyString2(part.callID);
-          const name = nonemptyString2(part.tool);
+          const callId = nonemptyString3(part.callID);
+          const name = nonemptyString3(part.tool);
           emit({
             type: "tool_call",
             args: jsonString(state.input),
@@ -1316,8 +1476,8 @@ var openCodeAdapter = {
             ...callTimestamp ? { timestamp: callTimestamp } : {},
             ...model ? { model } : {}
           });
-          const status = nonemptyString2(state.status);
-          const output = state.output !== undefined ? stringContent(state.output) : status === "error" ? errorContent(state.error) : undefined;
+          const status = nonemptyString3(state.status);
+          const output = state.output !== undefined ? stringContent2(state.output) : status === "error" ? errorContent(state.error) : undefined;
           if (output !== undefined) {
             emit({
               type: "tool_result",
@@ -1338,8 +1498,8 @@ var openCodeAdapter = {
         }
       }
     }
-    const cwd = nonemptyString2(sessionInfo.directory);
-    const sourceGroupId = nonemptyString2(sessionInfo.id);
+    const cwd = nonemptyString3(sessionInfo.directory);
+    const sourceGroupId = nonemptyString3(sessionInfo.id);
     const createdAt = parseTimestamp(isObject(sessionInfo.time) ? sessionInfo.time.created : undefined);
     return {
       events,
@@ -1365,10 +1525,10 @@ function parseOpenCodeDocument(transcript) {
   }
   return parsed;
 }
-function nonemptyString2(value) {
+function nonemptyString3(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
-function stringContent(value) {
+function stringContent2(value) {
   if (typeof value === "string")
     return value;
   if (value === null || value === undefined)
@@ -1378,7 +1538,7 @@ function stringContent(value) {
 function errorContent(value) {
   if (isObject(value) && typeof value.message === "string")
     return value.message;
-  return stringContent(value);
+  return stringContent2(value);
 }
 function invalidOpenCodeTranscript() {
   return new NormalizationError("invalid_input", "OpenCode transcript must be one JSON document with info and messages arrays of message parts.");
@@ -2906,7 +3066,7 @@ async function listTrajectories(input) {
   }
   const lister = LISTERS[input.source];
   if (!lister) {
-    throw new NormalizationError(input.source === "opencode" ? "listing_unavailable" : "unknown_source", input.source === "opencode" ? `Local trajectory listing is not available for ${JSON.stringify(input.source)}; supply an exported transcript directly to normalizeTranscript().` : `Unknown trajectory source ${JSON.stringify(input.source)}. Supported listing sources: ${Object.keys(LISTERS).join(", ")}.`);
+    throw new NormalizationError(isKnownNormalizationOnlySource(input.source) ? "listing_unavailable" : "unknown_source", isKnownNormalizationOnlySource(input.source) ? `Local trajectory listing is not available for ${JSON.stringify(input.source)}; supply an exported transcript directly to normalizeTranscript().` : `Unknown trajectory source ${JSON.stringify(input.source)}. Supported listing sources: ${Object.keys(LISTERS).join(", ")}.`);
   }
   if (input.root !== undefined && (typeof input.root !== "string" || !input.root)) {
     throw new NormalizationError("invalid_input", "root must be a non-empty string when provided.");
@@ -2914,6 +3074,9 @@ async function listTrajectories(input) {
   const limit = resolveLimit2(input.limit);
   const items = await lister(input.root);
   return paginate(items, input.cursor, limit);
+}
+function isKnownNormalizationOnlySource(source) {
+  return source === "gemini-cli" || source === "opencode";
 }
 function resolveLimit2(limit) {
   if (limit === undefined)
@@ -2965,6 +3128,7 @@ var ADAPTERS = {
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   droid: droidAdapter,
+  "gemini-cli": geminiCliAdapter,
   hermes: hermesAdapter,
   "letta-code": lettaCodeAdapter,
   openclaw: openClawAdapter,

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -28,6 +28,8 @@ FIXTURES = (
     ("codex", "codex/tool-calls", "input.jsonl"),
     ("codex", "codex/cleanup", "input.jsonl"),
     ("droid", "droid/happy-path", "input.jsonl"),
+    ("gemini-cli", "gemini-cli/tool-calls", "input.json"),
+    ("gemini-cli", "gemini-cli/cleanup", "input.json"),
     ("hermes", "hermes/tool-calls", "input.json"),
     ("hermes", "hermes/cleanup", "input.json"),
     ("letta-code", "letta-code/tool-calls", "input.jsonl"),

--- a/src/adapters/gemini-cli/README.md
+++ b/src/adapters/gemini-cli/README.md
@@ -1,0 +1,31 @@
+# gemini-cli
+
+The adapter accepts one native Gemini CLI session JSON document:
+
+```json
+{
+  "sessionId": "...",
+  "projectHash": "...",
+  "startTime": "...",
+  "messages": []
+}
+```
+
+`sessionId` supplies canonical session identity and `startTime` supplies the
+creation-time fallback. User messages may contain a string or text blocks.
+`gemini` messages preserve plaintext `thoughts` as reasoning, `content` as
+assistant prose, and the message model as metadata.
+
+Each `toolCalls` item emits a call using its native `id`, `name`, `args`, and
+timestamp. Inline `functionResponse.response.output` values become linked tool
+results. Other nonempty response objects, including structured errors, remain
+JSON. Terminal `success`, `error`, and `cancelled` statuses map to source-native
+`ok` values.
+
+`info` messages are CLI/harness notices and are dropped. Unknown message types
+are dropped with a diagnostic.
+
+This adapter accepts only the native whole-session shape. A session labelled
+“Gemini CLI” by an external corpus but containing Claude Code or another wire
+format must be routed to that format's adapter by the caller. Local-store
+discovery and format sniffing are intentionally out of scope.

--- a/src/adapters/gemini-cli/index.ts
+++ b/src/adapters/gemini-cli/index.ts
@@ -1,0 +1,203 @@
+import type {
+  DecodedEvent,
+  DecodedSession,
+  SourceAdapter,
+} from "../../internal.js";
+import type { Diagnostic } from "../../types.js";
+import { NormalizationError } from "../../types.js";
+import {
+  blocksText,
+  isObject,
+  jsonString,
+  parseTimestamp,
+} from "../shared.js";
+
+const TERMINAL_TOOL_STATUSES = new Set(["cancelled", "error", "success"]);
+
+/** Decode Gemini CLI's native whole-session JSON document. */
+export const geminiCliAdapter: SourceAdapter = {
+  source: "gemini-cli",
+
+  decode(transcript: string): DecodedSession {
+    const document = parseGeminiDocument(transcript);
+    const diagnostics: Diagnostic[] = [];
+    const events: DecodedEvent[] = [];
+
+    for (let messageIndex = 0; messageIndex < document.messages.length; messageIndex += 1) {
+      const message = document.messages[messageIndex];
+      if (!isObject(message)) continue;
+      const messageType = message.type;
+      if (messageType === "info") continue;
+
+      const timestamp = parseTimestamp(message.timestamp);
+      const model = nonemptyString(message.model);
+      const sourceRecordId = nonemptyString(message.id);
+      let componentIndex = 0;
+      const emit = (event: DecodedEvent): void => {
+        events.push({
+          ...event,
+          ...(sourceRecordId
+            ? { sourceRecordId }
+            : { sourceOffset: messageIndex, sourceAnchorKind: "ordinal" }),
+          sourceSequence: messageIndex,
+          componentIndex: componentIndex++,
+        });
+      };
+
+      if (messageType === "user") {
+        emit({
+          type: "message",
+          role: "user",
+          content: blocksText(message.content),
+          ...(timestamp ? { timestamp } : {}),
+        });
+        continue;
+      }
+
+      if (messageType !== "gemini") {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message:
+            `Skipped unsupported Gemini CLI message type ${JSON.stringify(messageType)} ` +
+            `at position ${messageIndex + 1}.`,
+        });
+        continue;
+      }
+
+      if (Array.isArray(message.thoughts)) {
+        for (const thought of message.thoughts) {
+          const content = thoughtContent(thought);
+          if (!content.trim()) continue;
+          emit({
+            type: "reasoning",
+            content,
+            ...(timestamp ? { timestamp } : {}),
+            ...(model ? { model } : {}),
+          });
+        }
+      }
+
+      const content = blocksText(message.content);
+      if (content.trim()) {
+        emit({
+          type: "message",
+          role: "assistant",
+          content,
+          ...(timestamp ? { timestamp } : {}),
+          ...(model ? { model } : {}),
+        });
+      }
+
+      if (!Array.isArray(message.toolCalls)) continue;
+      for (const rawCall of message.toolCalls) {
+        if (!isObject(rawCall)) continue;
+        const callId = nonemptyString(rawCall.id);
+        const name = nonemptyString(rawCall.name);
+        const callTimestamp = parseTimestamp(rawCall.timestamp) ?? timestamp;
+        emit({
+          type: "tool_call",
+          args: jsonString(rawCall.args),
+          ...(callId ? { id: callId } : {}),
+          ...(name ? { name } : {}),
+          ...(callTimestamp ? { timestamp: callTimestamp } : {}),
+          ...(model ? { model } : {}),
+        });
+
+        const status = nonemptyString(rawCall.status);
+        const outputs = toolOutputs(rawCall.result);
+        if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
+          continue;
+        }
+        emit({
+          type: "tool_result",
+          content: outputs.join("\n"),
+          ...(callId ? { callId } : {}),
+          ...(status === "success"
+            ? { ok: true }
+            : status === "error" || status === "cancelled"
+              ? { ok: false }
+              : {}),
+          ...(callTimestamp ? { timestamp: callTimestamp } : {}),
+          ...(model ? { model } : {}),
+        });
+      }
+    }
+
+    const sourceGroupId = nonemptyString(document.sessionId);
+    const createdAt = parseTimestamp(document.startTime);
+    return {
+      events,
+      context: {
+        source: "gemini-cli",
+        ...(sourceGroupId ? { sourceGroupId } : {}),
+        ...(createdAt ? { createdAt } : {}),
+      },
+      diagnostics,
+    };
+  },
+};
+
+interface GeminiDocument extends Record<string, unknown> {
+  messages: unknown[];
+}
+
+function parseGeminiDocument(transcript: string): GeminiDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidGeminiTranscript();
+  }
+  if (
+    !isObject(parsed) ||
+    !Array.isArray(parsed.messages) ||
+    (typeof parsed.sessionId !== "string" &&
+      typeof parsed.projectHash !== "string")
+  ) {
+    throw invalidGeminiTranscript();
+  }
+  return parsed as GeminiDocument;
+}
+
+function nonemptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function thoughtContent(value: unknown): string {
+  if (!isObject(value)) return String(value ?? "");
+  return ["subject", "description"]
+    .flatMap((key) =>
+      typeof value[key] === "string" && value[key] ? [value[key]] : [],
+    )
+    .join(" — ");
+}
+
+function toolOutputs(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const outputs: string[] = [];
+  for (const item of value) {
+    if (!isObject(item) || !isObject(item.functionResponse)) continue;
+    const response = item.functionResponse.response;
+    if (!isObject(response)) continue;
+    if (response.output !== undefined) {
+      outputs.push(stringContent(response.output));
+    } else if (Object.keys(response).length > 0) {
+      outputs.push(jsonString(response));
+    }
+  }
+  return outputs;
+}
+
+function stringContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  return isObject(value) || Array.isArray(value) ? jsonString(value) : String(value);
+}
+
+function invalidGeminiTranscript(): NormalizationError {
+  return new NormalizationError(
+    "invalid_input",
+    "Gemini CLI transcript must be one native session JSON document with " +
+      "session metadata and a messages array.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { claudeCodeAdapter } from "./adapters/claude-code/index.js";
 import { codexAdapter } from "./adapters/codex/index.js";
 import { droidAdapter } from "./adapters/droid/index.js";
+import { geminiCliAdapter } from "./adapters/gemini-cli/index.js";
 import { hermesAdapter } from "./adapters/hermes/index.js";
 import { lettaCodeAdapter } from "./adapters/letta-code/index.js";
 import { openClawAdapter } from "./adapters/openclaw/index.js";
@@ -30,6 +31,7 @@ const ADAPTERS: Record<TranscriptTrajectorySource, SourceAdapter> = {
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   droid: droidAdapter,
+  "gemini-cli": geminiCliAdapter,
   hermes: hermesAdapter,
   "letta-code": lettaCodeAdapter,
   openclaw: openClawAdapter,

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -87,8 +87,10 @@ export async function listTrajectories(
   const lister = LISTERS[input.source];
   if (!lister) {
     throw new NormalizationError(
-      input.source === "opencode" ? "listing_unavailable" : "unknown_source",
-      input.source === "opencode"
+      isKnownNormalizationOnlySource(input.source)
+        ? "listing_unavailable"
+        : "unknown_source",
+      isKnownNormalizationOnlySource(input.source)
         ? `Local trajectory listing is not available for ${JSON.stringify(input.source)}; supply an exported transcript directly to normalizeTranscript().`
         : `Unknown trajectory source ${JSON.stringify(input.source)}. Supported listing sources: ${Object.keys(LISTERS).join(", ")}.`,
     );
@@ -105,6 +107,10 @@ export async function listTrajectories(
   const limit = resolveLimit(input.limit);
   const items = await lister(input.root);
   return paginate(items, input.cursor, limit);
+}
+
+function isKnownNormalizationOnlySource(source: AnyTrajectorySource): boolean {
+  return source === "gemini-cli" || source === "opencode";
 }
 
 function resolveLimit(limit: number | undefined): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type TrajectorySource =
   | "claude-code"
   | "codex"
   | "droid"
+  | "gemini-cli"
   | "hermes"
   | "letta-code"
   | "omp"

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -41,6 +41,7 @@ const goldenFixtures = [
 }>;
 
 const additionalInvariantFixtures = [
+  { source: "gemini-cli", name: "gemini-cli/tool-calls" },
   { source: "opencode", name: "opencode/tool-calls" },
 ] as const satisfies ReadonlyArray<{
   source: TrajectorySource;
@@ -78,6 +79,7 @@ describe("canonical invariants", () => {
       const inputFile =
         fixture.source === "openhands" ||
         fixture.source === "hermes" ||
+        fixture.source === "gemini-cli" ||
         fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl";
@@ -109,18 +111,20 @@ describe("canonical invariants", () => {
   }
 });
 
-describe("OpenCode source-native identity", () => {
-  test("uses native part and message ids", () => {
-    const result = normalizeToCanonical({
-      source: "opencode",
-      transcript: fixtureText("opencode/tool-calls", "input.json"),
+describe("new source-native identity", () => {
+  for (const fixture of additionalInvariantFixtures) {
+    test(fixture.source, () => {
+      const result = normalizeToCanonical({
+        source: fixture.source,
+        transcript: fixtureText(fixture.name, "input.json"),
+      });
+      const body = result.records.filter((record) => record.record_type !== "meta");
+      expect(body.length).toBeGreaterThan(0);
+      expect(body.every((record) => record.source_identity_kind === "native")).toBe(
+        true,
+      );
     });
-    const body = result.records.filter((record) => record.record_type !== "meta");
-    expect(body.length).toBeGreaterThan(0);
-    expect(body.every((record) => record.source_identity_kind === "native")).toBe(
-      true,
-    );
-  });
+  }
 });
 
 describe("canonical tool result status", () => {

--- a/test/listing.test.ts
+++ b/test/listing.test.ts
@@ -127,9 +127,11 @@ afterAll(() => {
 
 describe("listTrajectories", () => {
   test("reports normalization-only sources without pretending to discover a store", async () => {
-    await expect(listTrajectories({ source: "opencode" })).rejects.toEqual(
-      expect.objectContaining({ code: "listing_unavailable" }),
-    );
+    for (const source of ["gemini-cli", "opencode"] as const) {
+      await expect(listTrajectories({ source })).rejects.toEqual(
+        expect.objectContaining({ code: "listing_unavailable" }),
+      );
+    }
   });
 
   test("lists claude-code parent and subagent sessions newest first", async () => {

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -17,6 +17,8 @@ const fixtures = [
   { source: "codex", name: "codex/tool-calls" },
   { source: "codex", name: "codex/cleanup" },
   { source: "droid", name: "droid/happy-path" },
+  { source: "gemini-cli", name: "gemini-cli/tool-calls" },
+  { source: "gemini-cli", name: "gemini-cli/cleanup" },
   { source: "hermes", name: "hermes/tool-calls" },
   { source: "hermes", name: "hermes/cleanup" },
   { source: "letta-code", name: "letta-code/tool-calls" },
@@ -52,6 +54,7 @@ describe("golden fixtures", () => {
         fixture.name,
         fixture.source === "openhands" ||
           fixture.source === "hermes" ||
+          fixture.source === "gemini-cli" ||
           fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl",
@@ -349,6 +352,15 @@ describe("public API", () => {
     ).toThrow(expect.objectContaining({ code: "invalid_input" }));
   });
 
+  test("rejects an invalid gemini-cli document shape", () => {
+    expect(() =>
+      normalizeTranscript({
+        source: "gemini-cli",
+        transcript: "{}",
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
   test("rejects an invalid opencode document shape", () => {
     expect(() =>
       normalizeTranscript({
@@ -408,6 +420,7 @@ describe("public API", () => {
         fixture.name,
         fixture.source === "openhands" ||
           fixture.source === "hermes" ||
+          fixture.source === "gemini-cli" ||
           fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl",


### PR DESCRIPTION
## Summary

- normalize native Gemini CLI whole-session JSON with thoughts, assistant content, inline tool calls/results, metadata, and terminal status
- preserve native message identity for canonical normalization
- add sanitized fixtures, TypeScript/Python parity coverage, and adapter contract documentation
- report `listing_unavailable` for caller-supplied exports

## Stack

The CI/Python parity and OpenCode prerequisites landed in #31 and #32. This is now the first outstanding adapter PR in the stack.

## Testing

- `bun run check` (145 passed, 7 optional-dependency skips)
- `PYTHONPATH="$PWD/python/src" python3.12 -m unittest discover -s python/tests -v` (11 passed, 1 optional-dependency skip)
- `git diff --check`