### PR TITLE
Add Cursor transcript adapter

### DIFF
--- a/CANONICAL.md
+++ b/CANONICAL.md
@@ -69,16 +69,17 @@ normalizeToCanonical({ source, transcript, sourceContext: { groupId, baseByteOff
   can be quarantined.
 - `baseByteOffset` — the absolute UTF-8 byte offset of this transcript within its
   source generation. It is added only to **byte-anchored** location identities
-  (Codex and id-less Claude Code/OpenClaw rows), making them stable regardless
-  of chunk boundaries. Ordinal anchors (Deep Agents) ignore it, and the
+  (Codex, Cursor, and id-less Claude Code/OpenClaw rows), making them stable
+  regardless of chunk boundaries. Ordinal anchors (Deep Agents) ignore it, and the
   anchor unit is part of the identity so byte and ordinal anchors never collide.
 
-Codex is `location`-anchored and therefore **requires** a resolved group
-(detected `session_meta` or `sourceContext.groupId`); it fails with
-`source_group_required` rather than falling back to the `default` sentinel, which
-would turn missing context into durable bad identity. Absolute byte offsets are
-only stable within one append-only generation; a truncation/replacement is a new
-generation upstream (worker-owned).
+Codex and Cursor are `location`-anchored and therefore **require** a resolved
+group. Codex may detect it from `session_meta`; Cursor's capture has no session
+field, so its caller passes `sourceContext.groupId`. Both fail with
+`source_group_required` rather than falling back to the `default` sentinel,
+which would turn missing context into durable bad identity. Absolute byte
+offsets are only stable within one append-only generation; a
+truncation/replacement is a new generation upstream (worker-owned).
 
 Both `normalizeTranscript()` and `normalizeToCanonical()` support
 **partial-transcript semantics** for a fragment of a larger conversation.
@@ -122,8 +123,9 @@ confidently it can interpret conflicts:
   `source_message_id`/`source_line_id`, OpenHands event `id`). Supports
   exact-duplicate dedup **and** conflicting-version detection.
 - `location` — a stable source-native location anchor when no native id exists:
-  an absolute UTF-8 byte offset for Codex and id-less Claude Code/OpenClaw rows
-  (chunkable via `baseByteOffset`), a whole-decode ordinal for Deep Agents, or
+  an absolute UTF-8 byte offset for Codex, Cursor, and id-less Claude
+  Code/OpenClaw rows (chunkable via `baseByteOffset`), a whole-decode ordinal for
+  Deep Agents, or
   the JSONL row position for id-less Letta Code rows.
   The anchor unit is part of the identity, so byte and ordinal anchors never
   collide. Supports dedup and conflict detection for append-only assembly.

--- a/PARITY.md
+++ b/PARITY.md
@@ -192,3 +192,22 @@ Sanitized happy-path and cleanup fixtures cover thoughts, prose, linked inline
 tool responses, structured status, unsupported message diagnostics, metadata,
 and canonical native identity. The audit retained no transcript content,
 arguments, results, paths, or identifiers.
+
+## Cursor SWE-chat capture
+
+The Cursor adapter targets the role/message JSONL capture present in the
+public `SALT-NLP/SWE-chat` raw transcripts. A privacy-safe audit covered all 19
+Cursor exports and inspected only aggregate keys, field types, block types,
+and file sizes.
+
+Every observed capture used `text` and `tool_use` content blocks. The corpus
+contained no timestamps, native record IDs, tool-call IDs, or tool results, so
+deterministic synthesized timestamps/call IDs and byte-offset canonical
+identity are expected for this source. All 19 captures normalized successfully
+(1,331 records) when canonical calls were supplied the corpus session ID.
+
+Sanitized fixtures additionally exercise the compatible `thinking` and
+`tool_result` blocks, including native IDs and structured error status when
+present. Cleanup coverage includes malformed lines, unsupported rows/blocks,
+and the required caller-owned canonical group. No source transcript content
+was retained.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ and is empty when the transcript required no recoverable cleanup.
 | --- | --- | --- |
 | [`claude-code`](src/adapters/claude-code/) | Native Claude Code JSONL | `claude-code` |
 | [`codex`](src/adapters/codex/) | Native Codex rollout JSONL | `codex` |
+| [`cursor`](src/adapters/cursor/) | Cursor role/message content-block JSONL capture | `cursor` |
 | [`droid`](src/adapters/droid/) | Native Droid session JSONL | `droid` |
 | [`gemini-cli`](src/adapters/gemini-cli/) | Native Gemini CLI whole-session JSON | `gemini-cli` |
 | [`hermes`](src/adapters/hermes/) | Session-store message-row array or a `{ "session": {...}, "messages": [...] }` envelope | `hermes` |
@@ -87,7 +88,7 @@ and is empty when the transcript required no recoverable cleanup.
 
 Tool result records may include `ok: boolean` when the source exposes an
 authoritative structured outcome, such as Pi/OpenClaw `isError`, Claude Code
-`is_error`, Letta Code `resultOk`, OpenHands observation `is_error`, or
+`is_error`, Letta Code `resultOk`, OpenHands/Cursor `is_error`, or
 OpenCode/Gemini terminal state. The field is omitted when the source does not
 expose a reliable status; result text is never interpreted as success or
 failure.
@@ -101,8 +102,9 @@ what the adapter drops.
 `listTrajectories()` enumerates the sessions in a source's standard local
 store, newest first, with cursor pagination. It is a discovery layer beside
 normalization — `normalizeTranscript()` itself never touches the filesystem.
-Gemini CLI and OpenCode are export-only input contracts and intentionally
-return `listing_unavailable`; callers locate and read the exports themselves.
+Cursor, Gemini CLI, and OpenCode are export-only input contracts and
+intentionally return `listing_unavailable`; callers locate and read the
+exports themselves.
 
 ```ts
 import { listTrajectories } from "@letta-ai/trajectory";

--- a/fixtures/cursor/cleanup/expected.json
+++ b/fixtures/cursor/cleanup/expected.json
@@ -1,0 +1,54 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "cursor"
+    },
+    {
+      "role": "user",
+      "content": "Run the failing command.",
+      "timestamp": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "cursor-call-error",
+          "name": "shell",
+          "args": "{\"command\":\"false\"}"
+        }
+      ],
+      "timestamp": "2026-01-01T00:00:15.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "cursor-call-error",
+      "content": "command failed",
+      "ok": false,
+      "timestamp": "2026-01-01T00:00:30.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "invalid_json_line",
+      "message": "Skipped invalid JSON on line 1.",
+      "inputLine": 1
+    },
+    {
+      "code": "noise_record_dropped",
+      "message": "Skipped unsupported Cursor row on line 2.",
+      "inputLine": 2
+    },
+    {
+      "code": "noise_record_dropped",
+      "message": "Skipped unsupported Cursor content block \"future-block\" on line 4.",
+      "inputLine": 4
+    },
+    {
+      "code": "timestamps_synthesized",
+      "message": "Synthesized timestamps for 3 normalized records.",
+      "count": 3
+    }
+  ]
+}

--- a/fixtures/cursor/cleanup/input.jsonl
+++ b/fixtures/cursor/cleanup/input.jsonl
@@ -1,0 +1,5 @@
+{not-json
+{"role":"system","message":{"content":"transport"}}
+{"role":"user","message":{"content":"Run the failing command."}}
+{"role":"assistant","message":{"content":[{"type":"tool_use","id":"cursor-call-error","name":"shell","input":{"command":"false"}},{"type":"future-block","value":"ignored"}]}}
+{"role":"user","message":{"content":[{"type":"tool_result","tool_use_id":"cursor-call-error","content":[{"type":"text","text":"command failed"}],"is_error":true}]}}

--- a/fixtures/cursor/tool-calls/expected.json
+++ b/fixtures/cursor/tool-calls/expected.json
@@ -1,0 +1,43 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "cursor",
+      "model": "cursor-test"
+    },
+    {
+      "role": "user",
+      "content": "Build the backend.",
+      "timestamp": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "role": "reasoning",
+      "content": "I should start with the API.",
+      "timestamp": "2026-01-01T00:00:15.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "Starting with the API.",
+      "timestamp": "2026-01-01T00:00:30.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "cursor-call-1",
+          "name": "write",
+          "args": "{\"path\":\"api.ts\"}"
+        }
+      ],
+      "timestamp": "2026-01-01T00:00:45.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "timestamps_synthesized",
+      "message": "Synthesized timestamps for 4 normalized records.",
+      "count": 4
+    }
+  ]
+}

--- a/fixtures/cursor/tool-calls/input.jsonl
+++ b/fixtures/cursor/tool-calls/input.jsonl
@@ -1,0 +1,2 @@
+{"id":"cursor-user","role":"user","message":{"content":[{"type":"text","text":"Build the backend."}]}}
+{"id":"cursor-assistant","role":"assistant","message":{"model":"cursor-test","content":[{"type":"thinking","thinking":"I should start with the API."},{"type":"text","text":"Starting with the API."},{"type":"tool_use","id":"cursor-call-1","name":"write","input":{"path":"api.ts"}}]}}

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -3,11 +3,11 @@
 from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal[
-    "claude-code", "codex", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
+    "claude-code", "codex", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
 ]
 CheckpointTrajectorySource = Literal["deepagents"]
 AnyTrajectorySource = Literal[
-    "claude-code", "codex", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
+    "claude-code", "codex", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 ToolResultPolicy = Literal["include", "omit"]

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -467,6 +467,101 @@ function outputText(output) {
   return output == null ? "" : String(output);
 }
 
+// src/adapters/cursor/index.ts
+var cursorAdapter = {
+  source: "cursor",
+  decode(transcript) {
+    const diagnostics = [];
+    const events = [];
+    let recognizedRows = 0;
+    for (const { value: row, line, byteOffset } of parseJsonLines(transcript, diagnostics)) {
+      if (row.role !== "user" && row.role !== "assistant" || !isObject(row.message)) {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message: `Skipped unsupported Cursor row on line ${line}.`,
+          inputLine: line
+        });
+        continue;
+      }
+      recognizedRows += 1;
+      const role = row.role;
+      const model = typeof row.message.model === "string" && row.message.model ? row.message.model : undefined;
+      const content = row.message.content;
+      const blocks = Array.isArray(content) ? content : [{ type: "text", text: typeof content === "string" ? content : "" }];
+      const sourceRecordId = typeof row.id === "string" && row.id ? row.id : undefined;
+      let componentIndex = 0;
+      const emit = (event) => {
+        events.push({
+          ...event,
+          ...sourceRecordId ? { sourceRecordId } : { sourceOffset: byteOffset, sourceAnchorKind: "byte" },
+          sourceSequence: line - 1,
+          componentIndex: componentIndex++,
+          inputLine: line
+        });
+      };
+      for (const block of blocks) {
+        if (!isObject(block))
+          continue;
+        if (block.type === "text") {
+          emit({
+            type: "message",
+            role,
+            content: typeof block.text === "string" ? block.text : "",
+            ...model ? { model } : {}
+          });
+        } else if (block.type === "thinking") {
+          emit({
+            type: "reasoning",
+            content: typeof block.thinking === "string" ? block.thinking : "",
+            ...model ? { model } : {}
+          });
+        } else if (block.type === "tool_use") {
+          emit({
+            type: "tool_call",
+            args: jsonString(block.input),
+            ...typeof block.id === "string" && block.id ? { id: block.id } : {},
+            ...typeof block.name === "string" && block.name ? { name: block.name } : {},
+            ...model ? { model } : {}
+          });
+        } else if (block.type === "tool_result") {
+          emit({
+            type: "tool_result",
+            content: resultContent(block.content),
+            ...typeof block.tool_use_id === "string" && block.tool_use_id ? { callId: block.tool_use_id } : {},
+            ...typeof block.is_error === "boolean" ? { ok: !block.is_error } : {},
+            ...model ? { model } : {}
+          });
+        } else {
+          diagnostics.push({
+            code: "noise_record_dropped",
+            message: `Skipped unsupported Cursor content block ${JSON.stringify(block.type)} ` + `on line ${line}.`,
+            inputLine: line
+          });
+        }
+      }
+    }
+    if (recognizedRows === 0)
+      throw invalidCursorTranscript();
+    return {
+      events,
+      context: { source: "cursor" },
+      diagnostics
+    };
+  }
+};
+function resultContent(value) {
+  if (typeof value === "string")
+    return value;
+  if (Array.isArray(value))
+    return blocksText(value);
+  if (value === null || value === undefined)
+    return "";
+  return isObject(value) ? jsonString(value) : String(value);
+}
+function invalidCursorTranscript() {
+  return new NormalizationError("invalid_input", "Cursor transcript must be JSONL with role and message.content records.");
+}
+
 // src/adapters/droid/index.ts
 var TRANSPORT_TYPES2 = new Set([
   "todo_state",
@@ -3076,7 +3171,7 @@ async function listTrajectories(input) {
   return paginate(items, input.cursor, limit);
 }
 function isKnownNormalizationOnlySource(source) {
-  return source === "gemini-cli" || source === "opencode";
+  return source === "cursor" || source === "gemini-cli" || source === "opencode";
 }
 function resolveLimit2(limit) {
   if (limit === undefined)
@@ -3127,6 +3222,7 @@ function invalidCursor() {
 var ADAPTERS = {
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
+  cursor: cursorAdapter,
   droid: droidAdapter,
   "gemini-cli": geminiCliAdapter,
   hermes: hermesAdapter,

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -27,6 +27,8 @@ FIXTURES = (
     ("claude-code", "claude-code/cleanup", "input.jsonl"),
     ("codex", "codex/tool-calls", "input.jsonl"),
     ("codex", "codex/cleanup", "input.jsonl"),
+    ("cursor", "cursor/tool-calls", "input.jsonl"),
+    ("cursor", "cursor/cleanup", "input.jsonl"),
     ("droid", "droid/happy-path", "input.jsonl"),
     ("gemini-cli", "gemini-cli/tool-calls", "input.json"),
     ("gemini-cli", "gemini-cli/cleanup", "input.json"),

--- a/src/adapters/cursor/README.md
+++ b/src/adapters/cursor/README.md
@@ -1,0 +1,27 @@
+# cursor
+
+The adapter accepts the Cursor capture JSONL used by SWE-chat. Each line is:
+
+```json
+{ "role": "user | assistant", "message": { "content": [] } }
+```
+
+Content may also be a scalar string. `text`, `thinking`, `tool_use`, and
+`tool_result` blocks become prose, reasoning, tool calls, and linked results.
+Tool arguments remain structured JSON. When present, block call IDs and
+`is_error` are preserved.
+
+The observed SWE-chat Cursor capture omits timestamps, top-level record IDs,
+tool-call IDs, and tool results. In that native subset the shared core
+synthesizes deterministic timestamps and call IDs, while canonical source
+identity anchors to each JSONL row's UTF-8 byte offset. The adapter also accepts
+the same content-block shape when IDs or results are present.
+
+The transcript itself has no session identifier. Callers using
+`normalizeToCanonical()` must therefore pass the corpus/session ID as
+`sourceContext.groupId`; trajectory-v1 `normalizeTranscript()` needs no extra
+context.
+
+Malformed JSONL lines and unknown rows or content-block types are recoverable
+diagnostics. The capture is an exported transcript rather than a documented
+Cursor local store, so `listTrajectories()` is not supported.

--- a/src/adapters/cursor/index.ts
+++ b/src/adapters/cursor/index.ts
@@ -1,0 +1,137 @@
+import type {
+  DecodedEvent,
+  DecodedSession,
+  SourceAdapter,
+} from "../../internal.js";
+import type { Diagnostic } from "../../types.js";
+import { NormalizationError } from "../../types.js";
+import {
+  blocksText,
+  isObject,
+  jsonString,
+  parseJsonLines,
+} from "../shared.js";
+
+/** Decode Cursor's `{ role, message: { content } }` capture JSONL. */
+export const cursorAdapter: SourceAdapter = {
+  source: "cursor",
+
+  decode(transcript: string): DecodedSession {
+    const diagnostics: Diagnostic[] = [];
+    const events: DecodedEvent[] = [];
+    let recognizedRows = 0;
+
+    for (const { value: row, line, byteOffset } of parseJsonLines(
+      transcript,
+      diagnostics,
+    )) {
+      if (
+        (row.role !== "user" && row.role !== "assistant") ||
+        !isObject(row.message)
+      ) {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message: `Skipped unsupported Cursor row on line ${line}.`,
+          inputLine: line,
+        });
+        continue;
+      }
+      recognizedRows += 1;
+      const role = row.role;
+      const model =
+        typeof row.message.model === "string" && row.message.model
+          ? row.message.model
+          : undefined;
+      const content = row.message.content;
+      const blocks = Array.isArray(content)
+        ? content
+        : [{ type: "text", text: typeof content === "string" ? content : "" }];
+      const sourceRecordId =
+        typeof row.id === "string" && row.id ? row.id : undefined;
+      let componentIndex = 0;
+      const emit = (event: DecodedEvent): void => {
+        events.push({
+          ...event,
+          ...(sourceRecordId
+            ? { sourceRecordId }
+            : { sourceOffset: byteOffset, sourceAnchorKind: "byte" }),
+          sourceSequence: line - 1,
+          componentIndex: componentIndex++,
+          inputLine: line,
+        });
+      };
+
+      for (const block of blocks) {
+        if (!isObject(block)) continue;
+        if (block.type === "text") {
+          emit({
+            type: "message",
+            role,
+            content: typeof block.text === "string" ? block.text : "",
+            ...(model ? { model } : {}),
+          });
+        } else if (block.type === "thinking") {
+          emit({
+            type: "reasoning",
+            content:
+              typeof block.thinking === "string" ? block.thinking : "",
+            ...(model ? { model } : {}),
+          });
+        } else if (block.type === "tool_use") {
+          emit({
+            type: "tool_call",
+            args: jsonString(block.input),
+            ...(typeof block.id === "string" && block.id
+              ? { id: block.id }
+              : {}),
+            ...(typeof block.name === "string" && block.name
+              ? { name: block.name }
+              : {}),
+            ...(model ? { model } : {}),
+          });
+        } else if (block.type === "tool_result") {
+          emit({
+            type: "tool_result",
+            content: resultContent(block.content),
+            ...(typeof block.tool_use_id === "string" && block.tool_use_id
+              ? { callId: block.tool_use_id }
+              : {}),
+            ...(typeof block.is_error === "boolean"
+              ? { ok: !block.is_error }
+              : {}),
+            ...(model ? { model } : {}),
+          });
+        } else {
+          diagnostics.push({
+            code: "noise_record_dropped",
+            message:
+              `Skipped unsupported Cursor content block ${JSON.stringify(block.type)} ` +
+              `on line ${line}.`,
+            inputLine: line,
+          });
+        }
+      }
+    }
+
+    if (recognizedRows === 0) throw invalidCursorTranscript();
+    return {
+      events,
+      context: { source: "cursor" },
+      diagnostics,
+    };
+  },
+};
+
+function resultContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return blocksText(value);
+  if (value === null || value === undefined) return "";
+  return isObject(value) ? jsonString(value) : String(value);
+}
+
+function invalidCursorTranscript(): NormalizationError {
+  return new NormalizationError(
+    "invalid_input",
+    "Cursor transcript must be JSONL with role and message.content records.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { claudeCodeAdapter } from "./adapters/claude-code/index.js";
 import { codexAdapter } from "./adapters/codex/index.js";
+import { cursorAdapter } from "./adapters/cursor/index.js";
 import { droidAdapter } from "./adapters/droid/index.js";
 import { geminiCliAdapter } from "./adapters/gemini-cli/index.js";
 import { hermesAdapter } from "./adapters/hermes/index.js";
@@ -30,6 +31,7 @@ import { NormalizationError } from "./types.js";
 const ADAPTERS: Record<TranscriptTrajectorySource, SourceAdapter> = {
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
+  cursor: cursorAdapter,
   droid: droidAdapter,
   "gemini-cli": geminiCliAdapter,
   hermes: hermesAdapter,
@@ -122,8 +124,8 @@ function isPartialTranscript(input: NormalizeInput): boolean {
  * Resolve the authoritative source group. Caller context fills a missing
  * adapter-detected group but must not silently override a detected one: a
  * disagreement fails so the upload can be quarantined. Location-anchored sources
- * (Codex) require a resolved group rather than falling back to a sentinel, which
- * would turn missing context into durable bad identity.
+ * (Codex and Cursor) require a resolved group rather than falling back to a
+ * sentinel, which would turn missing context into durable bad identity.
  */
 function resolveGroupId(
   source: TranscriptTrajectorySource,
@@ -137,10 +139,13 @@ function resolveGroupId(
     );
   }
   const resolved = detected || provided;
-  if (source === "codex" && !resolved) {
+  if ((source === "codex" || source === "cursor") && !resolved) {
+    const sourceLabel = source === "codex" ? "Codex" : "Cursor";
+    const discoveryHint = source === "codex" ? "include session_meta or " : "";
     throw new NormalizationError(
       "source_group_required",
-      "Canonical Codex normalization requires a source group: include session_meta or pass sourceContext.groupId.",
+      `Canonical ${sourceLabel} normalization requires a source group: ` +
+        `${discoveryHint}pass sourceContext.groupId.`,
     );
   }
   return resolved || GROUP_SENTINEL;

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -110,7 +110,11 @@ export async function listTrajectories(
 }
 
 function isKnownNormalizationOnlySource(source: AnyTrajectorySource): boolean {
-  return source === "gemini-cli" || source === "opencode";
+  return (
+    source === "cursor" ||
+    source === "gemini-cli" ||
+    source === "opencode"
+  );
 }
 
 function resolveLimit(limit: number | undefined): number {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@ import type { ResolvedNormalizationFilters } from "./filters.js";
 export type TrajectorySource =
   | "claude-code"
   | "codex"
+  | "cursor"
   | "droid"
   | "gemini-cli"
   | "hermes"

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -41,6 +41,7 @@ const goldenFixtures = [
 }>;
 
 const additionalInvariantFixtures = [
+  { source: "cursor", name: "cursor/tool-calls" },
   { source: "gemini-cli", name: "gemini-cli/tool-calls" },
   { source: "opencode", name: "opencode/tool-calls" },
 ] as const satisfies ReadonlyArray<{
@@ -86,6 +87,9 @@ describe("canonical invariants", () => {
       const result = normalizeToCanonical({
         source: fixture.source,
         transcript: fixtureText(fixture.name, inputFile),
+        ...(fixture.source === "cursor"
+          ? { sourceContext: { groupId: "cursor-session" } }
+          : {}),
       });
 
       const first = result.records[0];
@@ -112,7 +116,9 @@ describe("canonical invariants", () => {
 });
 
 describe("new source-native identity", () => {
-  for (const fixture of additionalInvariantFixtures) {
+  for (const fixture of additionalInvariantFixtures.filter(
+    ({ source }) => source !== "cursor",
+  )) {
     test(fixture.source, () => {
       const result = normalizeToCanonical({
         source: fixture.source,
@@ -125,6 +131,28 @@ describe("new source-native identity", () => {
       );
     });
   }
+
+  test("Cursor falls back to stable JSONL byte offsets when row ids are absent", () => {
+    const result = normalizeToCanonical({
+      source: "cursor",
+      transcript: fixtureText("cursor/cleanup", "input.jsonl"),
+      sourceContext: { groupId: "cursor-cleanup-session" },
+    });
+    const body = result.records.filter((record) => record.record_type !== "meta");
+    expect(body.length).toBeGreaterThan(0);
+    expect(body.every((record) => record.source_identity_kind === "location")).toBe(
+      true,
+    );
+  });
+
+  test("Cursor canonical normalization requires the caller's session id", () => {
+    expect(() =>
+      normalizeToCanonical({
+        source: "cursor",
+        transcript: fixtureText("cursor/tool-calls", "input.jsonl"),
+      }),
+    ).toThrow(expect.objectContaining({ code: "source_group_required" }));
+  });
 });
 
 describe("canonical tool result status", () => {

--- a/test/listing.test.ts
+++ b/test/listing.test.ts
@@ -127,7 +127,7 @@ afterAll(() => {
 
 describe("listTrajectories", () => {
   test("reports normalization-only sources without pretending to discover a store", async () => {
-    for (const source of ["gemini-cli", "opencode"] as const) {
+    for (const source of ["cursor", "gemini-cli", "opencode"] as const) {
       await expect(listTrajectories({ source })).rejects.toEqual(
         expect.objectContaining({ code: "listing_unavailable" }),
       );

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -16,6 +16,8 @@ const fixtures = [
   { source: "claude-code", name: "claude-code/subagent" },
   { source: "codex", name: "codex/tool-calls" },
   { source: "codex", name: "codex/cleanup" },
+  { source: "cursor", name: "cursor/tool-calls" },
+  { source: "cursor", name: "cursor/cleanup" },
   { source: "droid", name: "droid/happy-path" },
   { source: "gemini-cli", name: "gemini-cli/tool-calls" },
   { source: "gemini-cli", name: "gemini-cli/cleanup" },
@@ -368,6 +370,47 @@ describe("public API", () => {
         transcript: "{}",
       }),
     ).toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
+  test("rejects an invalid cursor document shape", () => {
+    expect(() =>
+      normalizeTranscript({
+        source: "cursor",
+        transcript: "{}",
+      }),
+    ).toThrow(expect.objectContaining({ code: "invalid_input" }));
+  });
+
+  test("synthesizes Cursor tool-call ids when the capture omits them", () => {
+    const transcript = [
+      JSON.stringify({
+        role: "user",
+        message: { content: [{ type: "text", text: "Create the file." }] },
+      }),
+      JSON.stringify({
+        role: "assistant",
+        message: {
+          content: [
+            {
+              type: "tool_use",
+              name: "write",
+              input: { path: "note.txt" },
+            },
+          ],
+        },
+      }),
+    ].join("\n");
+
+    const result = normalizeTranscript({ source: "cursor", transcript });
+    const call = result.records.find(
+      (record) => record.role === "assistant" && record.content === null,
+    );
+    expect(call?.role === "assistant" && call.content === null
+      ? call.tool_calls[0]?.id
+      : undefined).toBe("call_2");
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "tool_call_id_synthesized",
+    );
   });
 
   test("rejects Letta API message arrays", () => {


### PR DESCRIPTION
## Summary

- normalize Cursor role/message content-block JSONL with prose, reasoning, calls, optional results, and structured result status
- use byte-offset canonical identity when the capture omits record ids and require caller-supplied `sourceContext.groupId`
- add sanitized fixtures, TypeScript/Python parity coverage, and adapter/canonical contract documentation
- report `listing_unavailable` for caller-supplied exports

## Stack

The CI/Python parity, OpenCode, and Gemini CLI prerequisites landed in #31, #32, and #33. This is now the first outstanding adapter PR in the stack.

## Testing

- `bun run check` (153 passed, 7 optional-dependency skips)
- `PYTHONPATH="$PWD/python/src" python3.12 -m unittest discover -s python/tests -v` (11 passed, 1 optional-dependency skip)
- `git diff --check`