### PR TITLE
feat: publish the Python package to PyPI as agent-trajectory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   publish:
-    name: Bump, release, and publish to npm
+    name: Bump, release, and publish to npm and PyPI
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -44,6 +44,11 @@ jobs:
         with:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.10"
 
       - name: Bump version
         id: version
@@ -105,19 +110,41 @@ jobs:
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           fi
 
+          # npm prerelease versions ("0.3.0-next.1") are not valid PEP 440, so
+          # the Python distribution carries the normalized equivalent
+          # ("0.3.0rc1"). Stable releases are identical on both sides.
+          PY_VERSION=$(python3 - "$NEW_VERSION" <<'PY'
+          import re
+          import sys
+
+          version = sys.argv[1]
+          match = re.fullmatch(r"(\d+\.\d+\.\d+)(?:-([0-9A-Za-z-]+)\.(\d+))?", version)
+          if match is None:
+              sys.exit(f"Cannot derive a PEP 440 version from {version!r}.")
+
+          base, tag, number = match.groups()
+          if tag is None:
+              print(base)
+          else:
+              labels = {"a": "a", "alpha": "a", "b": "b", "beta": "b"}
+              print(f"{base}{labels.get(tag.lower(), 'rc')}{number}")
+          PY
+          )
+
           # The version is pinned in four places that version.test.ts (and the
           # Python parity tests) keep in lockstep; bump all of them together.
           jq --arg version "$NEW_VERSION" '.version = $version' package.json > package.json.tmp
           mv package.json.tmp package.json
           sed -i "s/^export const NORMALIZER_VERSION = \".*\";$/export const NORMALIZER_VERSION = \"$NEW_VERSION\";/" src/version.ts
-          sed -i "s/^version = \".*\"$/version = \"$NEW_VERSION\"/" pyproject.toml
-          sed -i "s/^__version__ = \".*\"$/__version__ = \"$NEW_VERSION\"/" python/src/trajectory/__init__.py
+          sed -i "s/^version = \".*\"$/version = \"$PY_VERSION\"/" pyproject.toml
+          sed -i "s/^__version__ = \".*\"$/__version__ = \"$PY_VERSION\"/" python/src/trajectory/__init__.py
           grep -q "NORMALIZER_VERSION = \"$NEW_VERSION\"" src/version.ts
-          grep -q "version = \"$NEW_VERSION\"" pyproject.toml
-          grep -q "__version__ = \"$NEW_VERSION\"" python/src/trajectory/__init__.py
+          grep -q "version = \"$PY_VERSION\"" pyproject.toml
+          grep -q "__version__ = \"$PY_VERSION\"" python/src/trajectory/__init__.py
 
           echo "old_version=$OLD_VERSION" >> $GITHUB_OUTPUT
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "py_version=$PY_VERSION" >> $GITHUB_OUTPUT
           echo "tag=v$NEW_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install dependencies
@@ -125,6 +152,17 @@ jobs:
 
       - name: Verify (typecheck, test, build)
         run: bun run check
+
+      - name: Verify Python parity
+        run: PYTHONPATH=python/src python -m unittest discover -s python/tests -v
+
+      # Built before anything is published so a packaging failure cannot leave
+      # npm and PyPI out of sync. `--outdir` avoids clobbering the tsc `dist/`.
+      - name: Build Python distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build --outdir dist-python
+          python -m twine check --strict dist-python/*
 
       - name: Commit and push version bump
         run: |
@@ -148,3 +186,9 @@ jobs:
         run: npm publish --access public --provenance --tag ${{ steps.version.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to PyPI
+        run: python -m twine upload --non-interactive dist-python/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ The TypeScript package is published as
 npm install @letta-ai/trajectory
 ```
 
+The Python wrapper is published as
+[`agent-trajectory`](https://pypi.org/project/agent-trajectory/) and imports as
+`trajectory`:
+
+```sh
+pip install agent-trajectory
+```
+
 ## Quick start
 
 ```ts

--- a/helpers/deepagents_checkpoint.py
+++ b/helpers/deepagents_checkpoint.py
@@ -31,7 +31,7 @@ except (ImportError, ModuleNotFoundError) as error:
         "python_dependency_missing",
         "Reading Deep Agents checkpoints requires Python packages "
         "langgraph and langgraph-checkpoint-sqlite; install the "
-        "letta-trajectory[deepagents] extra in this Python environment "
+        "agent-trajectory[deepagents] extra in this Python environment "
         f"(import error: {error}).",
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "letta-trajectory"
+name = "agent-trajectory"
 version = "0.2.2"
 description = "Normalize native agent transcripts into a shared trajectory format."
 readme = "README.md"

--- a/python/src/trajectory/_vendor/deepagents_checkpoint.py
+++ b/python/src/trajectory/_vendor/deepagents_checkpoint.py
@@ -31,7 +31,7 @@ except (ImportError, ModuleNotFoundError) as error:
         "python_dependency_missing",
         "Reading Deep Agents checkpoints requires Python packages "
         "langgraph and langgraph-checkpoint-sqlite; install the "
-        "letta-trajectory[deepagents] extra in this Python environment "
+        "agent-trajectory[deepagents] extra in this Python environment "
         f"(import error: {error}).",
     )
 

--- a/src/adapters/deepagents/README.md
+++ b/src/adapters/deepagents/README.md
@@ -31,7 +31,7 @@ wrapper reuses its own interpreter automatically, and its optional extra
 installs the LangGraph dependencies:
 
 ```sh
-pip install "letta-trajectory[deepagents] @ git+ssh://git@github.com/letta-ai/trajectory.git"
+pip install "agent-trajectory[deepagents]"
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Renames the Python distribution from `letta-trajectory` to **`agent-trajectory`** (the import name stays `trajectory`) and extends the release workflow to publish it to PyPI alongside the npm package.

## Changes

- **`pyproject.toml`** — `name = "agent-trajectory"`. The name is unclaimed on PyPI.
- **`release.yml`** — adds `Set up Python`, `Verify Python parity`, `Build Python distributions`, and `Publish to PyPI` (`twine upload`, authenticating with the new `PYPI_TOKEN` repo secret).
  - Distributions are built and `twine check --strict`ed **before** anything is published, so a packaging failure can't leave npm and PyPI out of sync.
  - `python -m build --outdir dist-python` avoids clobbering the tsc `dist/`. `dist-python/` is already gitignored.
- **`release.yml` bump step** — npm-style prerelease versions (`0.3.0-next.1`) are **not valid PEP 440**, so the old step wrote an unbuildable version into `pyproject.toml`. It now derives a normalized `py_version` for the two Python files: `-next.1` → `rc1`, `-beta.2` → `b2`, `-alpha.1` → `a1`, unknown tags → `rc`. Stable releases stay byte-identical across both ecosystems.
- **Docs** — `letta-trajectory[deepagents]` → `agent-trajectory[deepagents]` in the deepagents helper (plus its vendored copy) and adapter README, whose install line drops the `git+ssh://` URL now that the package is on PyPI. Adds a `pip install agent-trajectory` section to the root README.

## Testing

- `bun run check` (typecheck, 145 tests, build) and the Python parity suite (11 tests) pass.
- Real `python -m build` → `twine check --strict` **PASSED** on both sdist and wheel; the sdist carries `_vendor/trajectory-cli.mjs` and `py.typed`.
- Installed the built wheel into a clean venv as a consumer: imports `trajectory`, normalizes a transcript, and ships the vendored runtime.
- The version-derivation snippet was extracted from the YAML and exercised against eight version inputs, including the invalid-input failure path.