### PR TITLE
fix: normalize resumed Claude Code exports

### DIFF
--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -216,11 +216,10 @@ var claudeCodeAdapter = {
     if (agentIds.size > 1) {
       throw new NormalizationError("source_group_conflict", `Claude Code subagent transcript contains multiple agent ids: ${[...agentIds].map((id) => JSON.stringify(id)).sort().join(", ")}.`);
     }
-    if (sessionIds.size > 1 && (!standaloneSidechain || agentIds.size === 0)) {
-      throw new NormalizationError("source_group_conflict", `Claude Code transcript contains multiple session ids: ${[...sessionIds].map((id) => JSON.stringify(id)).sort().join(", ")}.`);
-    }
-    const [sessionId] = sessionIds;
+    const sessionId = sessionIds.size === 1 ? sessionIds.values().next().value : undefined;
     const [agentId] = agentIds;
+    const sourceGroupId = agentId ?? sessionId;
+    const sourceGroupAmbiguous = sessionIds.size > 1 && !agentId;
     const cwd = cwdCandidate?.value;
     const gitBranch = branchCandidate?.value;
     return {
@@ -229,7 +228,8 @@ var claudeCodeAdapter = {
         source: "claude-code",
         ...cwd ? { cwd } : {},
         ...gitBranch ? { gitBranch } : {},
-        ...agentId || sessionId ? { sourceGroupId: agentId || sessionId } : {}
+        ...sourceGroupId ? { sourceGroupId } : {},
+        ...sourceGroupAmbiguous ? { sourceGroupAmbiguous: true } : {}
       },
       diagnostics
     };

--- a/src/adapters/claude-code/README.md
+++ b/src/adapters/claude-code/README.md
@@ -16,6 +16,11 @@ conversation rows are present, the adapter treats the sidechain as the primary
 conversation and uses its `agentId` as the source group rather than the parent
 `sessionId`.
 
+Resumed or concatenated exports may contain records carrying multiple parent
+`sessionId` values. They remain valid trajectory-v1 input. Canonical callers
+must supply the authoritative export identity through
+`sourceContext.groupId`; the adapter does not guess among the embedded ids.
+
 Dropped input:
 
 - Sidechain records embedded alongside an ordinary parent conversation,

--- a/src/adapters/claude-code/index.ts
+++ b/src/adapters/claude-code/index.ts
@@ -200,23 +200,15 @@ export const claudeCodeAdapter: SourceAdapter = {
           .join(", ")}.`,
       );
     }
-    // A standalone subagent is grouped by its own agent id, so parent session-id
-    // drift does not make its identity ambiguous. Ordinary transcripts, and
-    // older subagent transcripts without agentId, still require one session id.
-    if (
-      sessionIds.size > 1 &&
-      (!standaloneSidechain || agentIds.size === 0)
-    ) {
-      throw new NormalizationError(
-        "source_group_conflict",
-        `Claude Code transcript contains multiple session ids: ${[...sessionIds]
-          .map((id) => JSON.stringify(id))
-          .sort()
-          .join(", ")}.`,
-      );
-    }
-    const [sessionId] = sessionIds;
+    // Resumed and concatenated exports can contain records from more than one
+    // parent session. That does not make trajectory-v1 normalization
+    // ambiguous, but canonical identity needs the caller to provide the
+    // authoritative file/session group instead of guessing among them.
+    const sessionId =
+      sessionIds.size === 1 ? sessionIds.values().next().value : undefined;
     const [agentId] = agentIds;
+    const sourceGroupId = agentId ?? sessionId;
+    const sourceGroupAmbiguous = sessionIds.size > 1 && !agentId;
     const cwd = cwdCandidate?.value;
     const gitBranch = branchCandidate?.value;
 
@@ -226,9 +218,8 @@ export const claudeCodeAdapter: SourceAdapter = {
         source: "claude-code",
         ...(cwd ? { cwd } : {}),
         ...(gitBranch ? { gitBranch } : {}),
-        ...(agentId || sessionId
-          ? { sourceGroupId: agentId || sessionId }
-          : {}),
+        ...(sourceGroupId ? { sourceGroupId } : {}),
+        ...(sourceGroupAmbiguous ? { sourceGroupAmbiguous: true } : {}),
       },
       diagnostics,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export function normalizeToCanonical(input: NormalizeInput): CanonicalResult {
     input.source,
     internal.context.sourceGroupId,
     input.sourceContext?.groupId,
+    internal.context.sourceGroupAmbiguous ?? false,
   );
   return finalizeCanonical(internal, bounds, {
     groupId,
@@ -133,7 +134,14 @@ function resolveGroupId(
   source: TranscriptTrajectorySource,
   detected: string | undefined,
   provided: string | undefined,
+  ambiguous: boolean,
 ): string {
+  if (ambiguous && !provided) {
+    throw new NormalizationError(
+      "source_group_required",
+      `Canonical ${source} normalization found multiple source groups; pass sourceContext.groupId.`,
+    );
+  }
   if (detected && provided && detected !== provided) {
     throw new NormalizationError(
       "source_group_conflict",
@@ -141,7 +149,9 @@ function resolveGroupId(
     );
   }
   const resolved = detected || provided;
-  if ((source === "codex" || source === "cursor") && !resolved) {
+  if (
+    (source === "codex" || source === "cursor") && !resolved
+  ) {
     const sourceLabel = source === "codex" ? "Codex" : "Cursor";
     const discoveryHint = source === "codex" ? "include session_meta or " : "";
     throw new NormalizationError(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -85,6 +85,11 @@ export interface SessionContext {
    * source-local sentinel downstream when a source has one implicit group.
    */
   sourceGroupId?: string;
+  /**
+   * The input contains more than one plausible source group. Canonical callers
+   * must provide the authoritative group instead of using a sentinel.
+   */
+  sourceGroupAmbiguous?: boolean;
 }
 
 export interface DecodedSession {

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -664,13 +664,22 @@ describe("meta determinism", () => {
     expect(reversedMeta?.record_hash).toBe(forwardMeta?.record_hash ?? "");
   });
 
-  test("multiple Claude Code session ids are rejected", () => {
+  test("multiple Claude Code session ids require an explicit canonical group", () => {
     const lines = [
       JSON.stringify({ type: "user", uuid: "u-1", sessionId: "s-1", timestamp: "2026-05-01T10:00:00.000Z", message: { role: "user", content: "hi" } }),
       JSON.stringify({ type: "assistant", uuid: "a-1", sessionId: "s-2", timestamp: "2026-05-01T10:00:01.000Z", message: { role: "assistant", content: [{ type: "text", text: "yo" }] } }),
     ];
     expect(() => canonical(lines)).toThrow(
-      expect.objectContaining({ code: "source_group_conflict" }),
+      expect.objectContaining({ code: "source_group_required" }),
+    );
+
+    const result = normalizeToCanonical({
+      source: "claude-code",
+      transcript: lines.join("\n"),
+      sourceContext: { groupId: "resumed-export" },
+    });
+    expect(new Set(result.records.map((record) => record.source_group_id))).toEqual(
+      new Set(["resumed-export"]),
     );
   });
 

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -127,6 +127,34 @@ describe("source-native tool result status", () => {
     expect(tool?.role === "tool" ? tool.ok : undefined).toBe(true);
   });
 
+  test("normalizes a resumed Claude Code export with multiple session ids", () => {
+    const transcript = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        sessionId: "parent-session",
+        message: { role: "user", content: "continue the task" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        sessionId: "resumed-session",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Continuing." }],
+        },
+      }),
+    ].join("\n");
+
+    const result = normalizeTranscript({ source: "claude-code", transcript });
+
+    expect(result.records.map((record) => record.role)).toEqual([
+      "meta",
+      "user",
+      "assistant",
+    ]);
+  });
+
   test("maps Letta Code resultOk", () => {
     const result = normalizeTranscript({
       source: "letta-code",


### PR DESCRIPTION
## Summary
- accept resumed or concatenated Claude Code exports containing multiple parent session IDs in trajectory-v1 normalization
- require an explicit `sourceContext.groupId` for canonical normalization instead of guessing the export identity
- preserve standalone subagent grouping by `agentId`

## Validation
- `bun run check` (160 passed, 7 skipped)
- `PYTHONPATH=python/src python3.12 -m unittest discover -s python/tests` (10 passed, 1 skipped)
- validated the affected native export shape without retaining transcript content