### PR TITLE
fix: accept Gemini CLI messages-only exports

### DIFF
--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -942,12 +942,14 @@ var geminiCliAdapter = {
       }
     }
     const sourceGroupId = nonemptyString2(document.sessionId);
+    const sourceGroupRequired = !sourceGroupId && !nonemptyString2(document.projectHash);
     const createdAt = parseTimestamp(document.startTime);
     return {
       events,
       context: {
         source: "gemini-cli",
         ...sourceGroupId ? { sourceGroupId } : {},
+        ...sourceGroupRequired ? { sourceGroupRequired: true } : {},
         ...createdAt ? { createdAt } : {}
       },
       diagnostics
@@ -961,7 +963,7 @@ function parseGeminiDocument(transcript) {
   } catch {
     throw invalidGeminiTranscript();
   }
-  if (!isObject(parsed) || !Array.isArray(parsed.messages) || typeof parsed.sessionId !== "string" && typeof parsed.projectHash !== "string") {
+  if (!isObject(parsed) || !Array.isArray(parsed.messages)) {
     throw invalidGeminiTranscript();
   }
   return parsed;
@@ -1000,7 +1002,7 @@ function stringContent(value) {
   return isObject(value) || Array.isArray(value) ? jsonString(value) : String(value);
 }
 function invalidGeminiTranscript() {
-  return new NormalizationError("invalid_input", "Gemini CLI transcript must be one native session JSON document with " + "session metadata and a messages array.");
+  return new NormalizationError("invalid_input", "Gemini CLI transcript must be one native session JSON document with a messages array.");
 }
 
 // src/adapters/hermes/index.ts

--- a/src/adapters/gemini-cli/README.md
+++ b/src/adapters/gemini-cli/README.md
@@ -11,10 +11,13 @@ The adapter accepts one native Gemini CLI session JSON document:
 }
 ```
 
-`sessionId` supplies canonical session identity and `startTime` supplies the
-creation-time fallback. User messages may contain a string or text blocks.
-`gemini` messages preserve plaintext `thoughts` as reasoning, `content` as
-assistant prose, and the message model as metadata.
+Only `messages` is required for trajectory-v1 normalization. Some native
+exports omit the surrounding session metadata; canonical callers must then
+supply the authoritative export identity through `sourceContext.groupId`.
+When present, `sessionId` supplies canonical session identity and `startTime`
+supplies the creation-time fallback. User messages may contain a string or text
+blocks. `gemini` messages preserve plaintext `thoughts` as reasoning, `content`
+as assistant prose, and the message model as metadata.
 
 Each `toolCalls` item emits a call using its native `id`, `name`, `args`, and
 timestamp. Inline `functionResponse.response.output` values become linked tool

--- a/src/adapters/gemini-cli/index.ts
+++ b/src/adapters/gemini-cli/index.ts
@@ -124,12 +124,15 @@ export const geminiCliAdapter: SourceAdapter = {
     }
 
     const sourceGroupId = nonemptyString(document.sessionId);
+    const sourceGroupRequired =
+      !sourceGroupId && !nonemptyString(document.projectHash);
     const createdAt = parseTimestamp(document.startTime);
     return {
       events,
       context: {
         source: "gemini-cli",
         ...(sourceGroupId ? { sourceGroupId } : {}),
+        ...(sourceGroupRequired ? { sourceGroupRequired: true } : {}),
         ...(createdAt ? { createdAt } : {}),
       },
       diagnostics,
@@ -150,9 +153,7 @@ function parseGeminiDocument(transcript: string): GeminiDocument {
   }
   if (
     !isObject(parsed) ||
-    !Array.isArray(parsed.messages) ||
-    (typeof parsed.sessionId !== "string" &&
-      typeof parsed.projectHash !== "string")
+    !Array.isArray(parsed.messages)
   ) {
     throw invalidGeminiTranscript();
   }
@@ -197,7 +198,6 @@ function stringContent(value: unknown): string {
 function invalidGeminiTranscript(): NormalizationError {
   return new NormalizationError(
     "invalid_input",
-    "Gemini CLI transcript must be one native session JSON document with " +
-      "session metadata and a messages array.",
+    "Gemini CLI transcript must be one native session JSON document with a messages array.",
   );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export function normalizeToCanonical(input: NormalizeInput): CanonicalResult {
     internal.context.sourceGroupId,
     input.sourceContext?.groupId,
     internal.context.sourceGroupAmbiguous ?? false,
+    internal.context.sourceGroupRequired ?? false,
   );
   return finalizeCanonical(internal, bounds, {
     groupId,
@@ -126,8 +127,9 @@ function isPartialTranscript(input: NormalizeInput): boolean {
 /**
  * Resolve the authoritative source group. Caller context fills a missing
  * adapter-detected group but must not silently override a detected one: a
- * disagreement fails so the upload can be quarantined. Location-anchored sources
- * (Codex and Cursor) require a resolved group rather than falling back to a
+ * disagreement fails so the upload can be quarantined. Location-anchored
+ * sources (Codex and Cursor), ambiguous inputs, and native shapes with no
+ * grouping metadata require a resolved group rather than falling back to a
  * sentinel, which would turn missing context into durable bad identity.
  */
 function resolveGroupId(
@@ -135,11 +137,18 @@ function resolveGroupId(
   detected: string | undefined,
   provided: string | undefined,
   ambiguous: boolean,
+  required: boolean,
 ): string {
   if (ambiguous && !provided) {
     throw new NormalizationError(
       "source_group_required",
       `Canonical ${source} normalization found multiple source groups; pass sourceContext.groupId.`,
+    );
+  }
+  if (required && !provided) {
+    throw new NormalizationError(
+      "source_group_required",
+      `Canonical ${source} normalization has no source group; pass sourceContext.groupId.`,
     );
   }
   if (detected && provided && detected !== provided) {
@@ -149,9 +158,7 @@ function resolveGroupId(
     );
   }
   const resolved = detected || provided;
-  if (
-    (source === "codex" || source === "cursor") && !resolved
-  ) {
+  if ((source === "codex" || source === "cursor") && !resolved) {
     const sourceLabel = source === "codex" ? "Codex" : "Cursor";
     const discoveryHint = source === "codex" ? "include session_meta or " : "";
     throw new NormalizationError(

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -90,6 +90,11 @@ export interface SessionContext {
    * must provide the authoritative group instead of using a sentinel.
    */
   sourceGroupAmbiguous?: boolean;
+  /**
+   * The source shape is valid but carries no native grouping metadata.
+   * Canonical callers must provide the authoritative group.
+   */
+  sourceGroupRequired?: boolean;
 }
 
 export interface DecodedSession {

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -158,6 +158,45 @@ describe("new source-native identity", () => {
       }),
     ).toThrow(expect.objectContaining({ code: "source_group_required" }));
   });
+
+  test("Gemini CLI messages-only exports require an explicit canonical group", () => {
+    const transcript = JSON.stringify({
+      messages: [
+        { type: "user", content: "Inspect the failure." },
+        { type: "gemini", content: "I will inspect it." },
+      ],
+    });
+
+    expect(() =>
+      normalizeToCanonical({ source: "gemini-cli", transcript }),
+    ).toThrow(expect.objectContaining({ code: "source_group_required" }));
+
+    const result = normalizeToCanonical({
+      source: "gemini-cli",
+      transcript,
+      sourceContext: { groupId: "messages-only-export" },
+    });
+    expect(new Set(result.records.map((record) => record.source_group_id))).toEqual(
+      new Set(["messages-only-export"]),
+    );
+  });
+
+  test("Gemini CLI projectHash-only exports retain the default canonical group", () => {
+    const result = normalizeToCanonical({
+      source: "gemini-cli",
+      transcript: JSON.stringify({
+        projectHash: "project-hash",
+        messages: [
+          { type: "user", content: "Inspect the failure." },
+          { type: "gemini", content: "I will inspect it." },
+        ],
+      }),
+    });
+
+    expect(new Set(result.records.map((record) => record.source_group_id))).toEqual(
+      new Set(["default"]),
+    );
+  });
 });
 
 describe("canonical tool result status", () => {

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -393,6 +393,24 @@ describe("public API", () => {
     ).toThrow(expect.objectContaining({ code: "invalid_input" }));
   });
 
+  test("normalizes a Gemini CLI messages-only export", () => {
+    const result = normalizeTranscript({
+      source: "gemini-cli",
+      transcript: JSON.stringify({
+        messages: [
+          { type: "user", content: "Inspect the failure." },
+          { type: "gemini", content: "I will inspect it." },
+        ],
+      }),
+    });
+
+    expect(result.records.map((record) => record.role)).toEqual([
+      "meta",
+      "user",
+      "assistant",
+    ]);
+  });
+
   test("rejects an invalid opencode document shape", () => {
     expect(() =>
       normalizeTranscript({


### PR DESCRIPTION
## Summary
- accept native Gemini CLI session documents that contain `messages` but omit surrounding session metadata in trajectory-v1 normalization
- require `sourceContext.groupId` for canonical normalization only when neither `sessionId` nor `projectHash` is available
- preserve the existing canonical fallback for `projectHash`-only exports
- document the identity boundary and cover both normalization views

## Validation
- `bun run check` (163 passed, 7 skipped)
- `PYTHONPATH=python/src python3.12 -m unittest discover -s python/tests` (10 passed, 1 skipped)
- validated the affected native export shape without retaining transcript content