### PR TITLE
feat: add ATIF trajectory source

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -17,6 +17,38 @@ only to a temporary directory for mismatches, classified without printing
 content, and deleted when the run exits. Files that change between passes are
 excluded using byte-level input hashes.
 
+## ATIF interchange format
+
+The ATIF adapter was implemented against the active Harbor ATIF RFC and its
+reference Pydantic models as of 2026-08-19. The reference accepts schema
+versions `ATIF-v1.0` through `ATIF-v1.7`; automated coverage exercises every
+published version plus a sanitized v1.7 trajectory containing multimodal
+content, reasoning, multiple tool calls, linked observations, model metadata,
+run/document identity, and an external subagent reference.
+
+A privacy-safe bulk pass then covered 3,373 Harbor-generated trajectories
+(499,643,224 bytes) from a local benchmark corpus: 403 ATIF-v1.2, 793
+ATIF-v1.5, and 2,177 ATIF-v1.6 documents produced by eight agent integrations.
+All files were valid JSON, all had `session_id`, and none changed during the
+pass. Strict whole-transcript normalization succeeded for 2,583 files; 746
+OpenCode exports omitted user steps and 44 otherwise incomplete exports omitted
+assistant steps, so they correctly failed the shared whole-conversation
+invariants. With explicit partial-transcript semantics, all 3,373 normalized
+successfully to 311,712 records. Canonical normalization also succeeded for all
+files with native identity for all 308,339 body records and no duplicate record
+IDs within a trajectory.
+
+The corpus exercised 118,613 tool calls and 89,366 observation results. Of the
+results, 33,845 intentionally had no `source_call_id` (the Terminus family uses
+one unlinked observation per agent step); all 33,845 were preserved as generic
+`observation` records without inventing tool links. The 609 system steps remain
+omitted by default and raise the explicit-inclusion total to 312,321 records.
+Other aggregate cleanup was 19,397 synthesized timestamps, 215 synthesized
+tool-call IDs, 87 argument truncations, and 9,519 result truncations under the
+default bounds. Intentional target-schema differences are documented beside
+the adapter: embedded subagent timelines, metrics, and custom metadata have no
+equivalent in trajectory-v1.
+
 ## Production TypeScript reference
 
 Reference: `letta-agent-sdk` `dream-pipeline` commit `3d3e3e0`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ and is empty when the transcript required no recoverable cleanup.
 
 | `source` | Accepted input format | Normalized `meta.source` |
 | --- | --- | --- |
+| [`atif`](src/adapters/atif/) | ATIF-v1.0 through ATIF-v1.7 whole-trajectory JSON | `atif` |
 | [`claude-code`](src/adapters/claude-code/) | Native Claude Code JSONL | `claude-code` |
 | [`codex`](src/adapters/codex/) | Native Codex rollout JSONL | `codex` |
 | [`copilot-cli`](src/adapters/copilot-cli/) | Native GitHub Copilot CLI event JSONL | `copilot-cli` |
@@ -111,9 +112,9 @@ what the adapter drops.
 `listTrajectories()` enumerates the sessions in a source's standard local
 store, newest first, with cursor pagination. It is a discovery layer beside
 normalization — `normalizeTranscript()` itself never touches the filesystem.
-Copilot CLI, Cursor, Gemini CLI, and OpenCode are export-only input contracts
-and intentionally return `listing_unavailable`; callers locate and read the
-exports themselves.
+ATIF, Copilot CLI, Cursor, Gemini CLI, and OpenCode are export-only input
+contracts and intentionally return `listing_unavailable`; callers locate and
+read the exports themselves.
 
 ```ts
 import { listTrajectories } from "@letta-ai/trajectory";

--- a/fixtures/atif/cleanup/expected.json
+++ b/fixtures/atif/cleanup/expected.json
@@ -1,0 +1,53 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "atif"
+    },
+    {
+      "role": "user",
+      "content": "Run the check.",
+      "timestamp": "2026-08-18T11:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call-check",
+          "name": "check",
+          "args": "{\"_raw\":\"[\\\"fast\\\"]\"}"
+        }
+      ],
+      "timestamp": "2026-08-18T11:00:02.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call-check",
+      "content": "Check complete.\n[image]",
+      "timestamp": "2026-08-18T11:00:02.000Z"
+    },
+    {
+      "role": "observation",
+      "content": "Environment reset complete.",
+      "timestamp": "2026-08-18T11:00:02.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "The check completed.",
+      "timestamp": "2026-08-18T11:00:03.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "noise_record_dropped",
+      "message": "Did not flatten 1 embedded ATIF subagent trajectory(ies); only root steps are normalized.",
+      "count": 1
+    },
+    {
+      "code": "tool_arguments_reshaped",
+      "message": "Reshaped arguments for tool call \"call-check\" into a JSON object.",
+      "recordIndex": 2
+    }
+  ]
+}

--- a/fixtures/atif/cleanup/input.json
+++ b/fixtures/atif/cleanup/input.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "ATIF-v1.7",
+  "trajectory_id": "trajectory-atif-cleanup",
+  "agent": {
+    "name": "example-agent",
+    "version": "1.0.0"
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "timestamp": "2026-08-18T11:00:00Z",
+      "source": "system",
+      "message": "Use the provided tools."
+    },
+    {
+      "step_id": 2,
+      "timestamp": "2026-08-18T11:00:01Z",
+      "source": "user",
+      "message": "Run the check."
+    },
+    {
+      "step_id": 3,
+      "timestamp": "2026-08-18T11:00:02Z",
+      "source": "agent",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call-check",
+          "function_name": "check",
+          "arguments": ["fast"]
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call-check",
+            "content": [
+              { "type": "text", "text": "Check complete." },
+              {
+                "type": "image",
+                "source": { "media_type": "image/png", "path": "images/result.png" }
+              }
+            ]
+          },
+          { "content": "Environment reset complete." }
+        ]
+      }
+    },
+    {
+      "step_id": 4,
+      "timestamp": "2026-08-18T11:00:03Z",
+      "source": "agent",
+      "message": "The check completed."
+    }
+  ],
+  "subagent_trajectories": [
+    {
+      "schema_version": "ATIF-v1.7",
+      "trajectory_id": "embedded-1",
+      "agent": { "name": "subagent", "version": "1.0.0" },
+      "steps": [
+        { "step_id": 1, "source": "user", "message": "Inspect config." },
+        { "step_id": 2, "source": "agent", "message": "Config is valid." }
+      ]
+    }
+  ]
+}

--- a/fixtures/atif/tool-calls/expected.json
+++ b/fixtures/atif/tool-calls/expected.json
@@ -1,0 +1,66 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "atif",
+      "model": "example-default-model"
+    },
+    {
+      "role": "user",
+      "content": "Inspect the workspace.\n[image]",
+      "timestamp": "2026-08-18T10:00:00.000Z"
+    },
+    {
+      "role": "reasoning",
+      "content": "I should list the files before reading one.",
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "I'll inspect it now.",
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call-list",
+          "name": "shell",
+          "args": "{\"command\":\"find . -maxdepth 1 -type f\"}"
+        }
+      ],
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call-delegate",
+          "name": "delegate",
+          "args": "{\"task\":\"inspect config\"}"
+        }
+      ],
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call-list",
+      "content": "README.md\npackage.json",
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "call-delegate",
+      "content": "{\"subagent_trajectory_ref\":[{\"trajectory_path\":\"subagents/config.json\",\"session_id\":\"run-atif-1\"}]}",
+      "timestamp": "2026-08-18T10:00:01.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": "The workspace contains the expected project files.",
+      "timestamp": "2026-08-18T10:00:02.000Z"
+    }
+  ],
+  "diagnostics": []
+}

--- a/fixtures/atif/tool-calls/input.json
+++ b/fixtures/atif/tool-calls/input.json
@@ -1,0 +1,70 @@
+{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "run-atif-1",
+  "trajectory_id": "trajectory-atif-1",
+  "agent": {
+    "name": "example-agent",
+    "version": "1.0.0",
+    "model_name": "example-default-model"
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "timestamp": "2026-08-18T10:00:00Z",
+      "source": "user",
+      "message": [
+        { "type": "text", "text": "Inspect the workspace." },
+        {
+          "type": "image",
+          "source": { "media_type": "image/png", "path": "images/workspace.png" }
+        }
+      ]
+    },
+    {
+      "step_id": 2,
+      "timestamp": "2026-08-18T10:00:01Z",
+      "source": "agent",
+      "model_name": "example-step-model",
+      "message": "I'll inspect it now.",
+      "reasoning_content": "I should list the files before reading one.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call-list",
+          "function_name": "shell",
+          "arguments": { "command": "find . -maxdepth 1 -type f" }
+        },
+        {
+          "tool_call_id": "call-delegate",
+          "function_name": "delegate",
+          "arguments": { "task": "inspect config" }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call-list",
+            "content": [
+              { "type": "text", "text": "README.md" },
+              { "type": "text", "text": "package.json" }
+            ]
+          },
+          {
+            "source_call_id": "call-delegate",
+            "subagent_trajectory_ref": [
+              {
+                "trajectory_path": "subagents/config.json",
+                "session_id": "run-atif-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 3,
+      "timestamp": "2026-08-18T10:00:02Z",
+      "source": "agent",
+      "message": "The workspace contains the expected project files."
+    }
+  ]
+}

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -3,11 +3,11 @@
 from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal[
-    "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
+    "atif", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
 ]
 CheckpointTrajectorySource = Literal["deepagents"]
 AnyTrajectorySource = Literal[
-    "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
+    "atif", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 ToolResultPolicy = Literal["include", "omit"]

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -102,9 +102,10 @@ var atifAdapter = {
     const document = parseAtifDocument(transcript);
     const diagnostics = [];
     const events = [];
-    const trajectoryId = nonemptyString(document.trajectory_id);
-    const sessionId = nonemptyString(document.session_id);
-    const rootModel = nonemptyString(document.agent.model_name);
+    const trajectoryId = atifNonemptyString(document.trajectory_id);
+    const sessionId = atifNonemptyString(document.session_id);
+    const rootModel = atifNonemptyString(document.agent.model_name);
+    let createdAt;
     for (let index = 0;index < document.steps.length; index += 1) {
       const step = document.steps[index];
       if (!isObject(step))
@@ -119,7 +120,8 @@ var atifAdapter = {
         throw invalidAtifTranscript();
       }
       const timestamp = parseTimestamp(step.timestamp);
-      const model = step.source === "agent" ? nonemptyString(step.model_name) ?? rootModel : undefined;
+      createdAt ??= timestamp;
+      const model = step.source === "agent" ? atifNonemptyString(step.model_name) ?? rootModel : undefined;
       const sourceRecordId = trajectoryId ? `trajectory:${trajectoryId}:step:${expectedStepId}` : `step:${expectedStepId}`;
       let componentIndex = 0;
       const emit = (event) => {
@@ -170,8 +172,8 @@ var atifAdapter = {
         for (const rawCall of step.tool_calls ?? []) {
           if (!isObject(rawCall))
             throw invalidAtifTranscript();
-          const callId = nonemptyString(rawCall.tool_call_id);
-          const name = nonemptyString(rawCall.function_name);
+          const callId = atifNonemptyString(rawCall.tool_call_id);
+          const name = atifNonemptyString(rawCall.function_name);
           emit({
             type: "tool_call",
             args: jsonString(rawCall.arguments),
@@ -189,7 +191,7 @@ var atifAdapter = {
       for (const rawResult of step.observation.results) {
         if (!isObject(rawResult))
           throw invalidAtifTranscript();
-        const callId = nonemptyString(rawResult.source_call_id);
+        const callId = atifNonemptyString(rawResult.source_call_id);
         const content = observationContent(rawResult);
         emit(callId ? { type: "tool_result", callId, content, ...shared } : { type: "observation", content, ...shared });
       }
@@ -201,7 +203,6 @@ var atifAdapter = {
         count: document.subagent_trajectories.length
       });
     }
-    const createdAt = document.steps.map((step) => isObject(step) ? parseTimestamp(step.timestamp) : undefined).find((value) => value !== undefined);
     const sourceGroupId = sessionId ?? trajectoryId;
     return {
       events,
@@ -242,7 +243,7 @@ function observationContent(result) {
   }
   return "";
 }
-function nonemptyString(value) {
+function atifNonemptyString(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function invalidAtifTranscript() {
@@ -670,21 +671,21 @@ var copilotCliAdapter = {
         continue;
       const data = isObject(row.data) ? row.data : {};
       if (row.type === "session.start") {
-        sourceGroupId ??= nonemptyString2(data.sessionId);
+        sourceGroupId ??= nonemptyString(data.sessionId);
         createdAt ??= parseTimestamp(data.startTime);
         const context = isObject(data.context) ? data.context : {};
-        cwd ??= nonemptyString2(context.cwd);
-        gitBranch ??= nonemptyString2(context.branch);
+        cwd ??= nonemptyString(context.cwd);
+        gitBranch ??= nonemptyString(context.branch);
       } else if (row.type === "hook.start" && data.hookType === "userPromptSubmitted") {
         const input = isObject(data.input) ? data.input : {};
-        sourceGroupId ??= nonemptyString2(input.sessionId);
-        cwd ??= nonemptyString2(input.cwd);
+        sourceGroupId ??= nonemptyString(input.sessionId);
+        cwd ??= nonemptyString(input.cwd);
       } else if (row.type === "tool.execution_complete") {
-        model ??= nonemptyString2(data.model);
+        model ??= nonemptyString(data.model);
       } else if (row.type === "session.model_change") {
-        model ??= nonemptyString2(data.newModel);
+        model ??= nonemptyString(data.newModel);
       } else if (row.type === "session.shutdown") {
-        model ??= nonemptyString2(data.currentModel);
+        model ??= nonemptyString(data.currentModel);
       }
     }
     for (const { value: row, line, byteOffset } of rows) {
@@ -700,7 +701,7 @@ var copilotCliAdapter = {
       recognizedRows += 1;
       const data = isObject(row.data) ? row.data : {};
       const timestamp = parseTimestamp(row.timestamp);
-      const sourceRecordId = nonemptyString2(row.id);
+      const sourceRecordId = nonemptyString(row.id);
       let componentIndex = 0;
       const emit = (event) => {
         events.push({
@@ -723,7 +724,7 @@ var copilotCliAdapter = {
         continue;
       }
       if (rowType === "assistant.message") {
-        const eventModel = nonemptyString2(data.model);
+        const eventModel = nonemptyString(data.model);
         if (typeof data.reasoningText === "string" && data.reasoningText.trim()) {
           emit({
             type: "reasoning",
@@ -745,8 +746,8 @@ var copilotCliAdapter = {
           for (const request of data.toolRequests) {
             if (!isObject(request))
               continue;
-            const callId = nonemptyString2(request.toolCallId);
-            const name = nonemptyString2(request.name);
+            const callId = nonemptyString(request.toolCallId);
+            const name = nonemptyString(request.name);
             emit({
               type: "tool_call",
               args: typeof request.arguments === "string" ? request.arguments : jsonString(request.arguments),
@@ -760,8 +761,8 @@ var copilotCliAdapter = {
         continue;
       }
       if (rowType === "tool.execution_complete") {
-        const callId = nonemptyString2(data.toolCallId);
-        const eventModel = nonemptyString2(data.model);
+        const callId = nonemptyString(data.toolCallId);
+        const eventModel = nonemptyString(data.model);
         emit({
           type: "tool_result",
           content: copilotResultContent(data),
@@ -788,7 +789,7 @@ var copilotCliAdapter = {
     };
   }
 };
-function nonemptyString2(value) {
+function nonemptyString(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function copilotResultContent(data) {
@@ -1022,8 +1023,8 @@ var geminiCliAdapter = {
       if (messageType === "info")
         continue;
       const timestamp = parseTimestamp(message.timestamp);
-      const model = nonemptyString3(message.model);
-      const sourceRecordId = nonemptyString3(message.id);
+      const model = nonemptyString2(message.model);
+      const sourceRecordId = nonemptyString2(message.id);
       let componentIndex = 0;
       const emit = (event) => {
         events.push({
@@ -1077,8 +1078,8 @@ var geminiCliAdapter = {
       for (const rawCall of message.toolCalls) {
         if (!isObject(rawCall))
           continue;
-        const callId = nonemptyString3(rawCall.id);
-        const name = nonemptyString3(rawCall.name);
+        const callId = nonemptyString2(rawCall.id);
+        const name = nonemptyString2(rawCall.name);
         const callTimestamp = parseTimestamp(rawCall.timestamp) ?? timestamp;
         emit({
           type: "tool_call",
@@ -1088,7 +1089,7 @@ var geminiCliAdapter = {
           ...callTimestamp ? { timestamp: callTimestamp } : {},
           ...model ? { model } : {}
         });
-        const status = nonemptyString3(rawCall.status);
+        const status = nonemptyString2(rawCall.status);
         const outputs = toolOutputs(rawCall.result);
         if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
           continue;
@@ -1104,8 +1105,8 @@ var geminiCliAdapter = {
         });
       }
     }
-    const sourceGroupId = nonemptyString3(document.sessionId);
-    const sourceGroupRequired = !sourceGroupId && !nonemptyString3(document.projectHash);
+    const sourceGroupId = nonemptyString2(document.sessionId);
+    const sourceGroupRequired = !sourceGroupId && !nonemptyString2(document.projectHash);
     const createdAt = parseTimestamp(document.startTime);
     return {
       events,
@@ -1131,7 +1132,7 @@ function parseGeminiDocument(transcript) {
   }
   return parsed;
 }
-function nonemptyString3(value) {
+function nonemptyString2(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function thoughtContent(value) {
@@ -1440,7 +1441,7 @@ var lettaCodeAdapter = {
     for (const { value: row } of rows) {
       if (row.kind !== "reasoning")
         continue;
-      const sourceRecordId = nonemptyString4(row.source_message_id) ?? nonemptyString4(row.source_line_id);
+      const sourceRecordId = nonemptyString3(row.source_message_id) ?? nonemptyString3(row.source_line_id);
       if (sourceRecordId)
         reasoningRecordIds.add(sourceRecordId);
     }
@@ -1463,8 +1464,8 @@ var lettaCodeAdapter = {
         continue;
       }
       const timestamp = parseTimestamp(row.captured_at);
-      const sourceMessageId = nonemptyString4(row.source_message_id);
-      const sourceLineId = nonemptyString4(row.source_line_id);
+      const sourceMessageId = nonemptyString3(row.source_message_id);
+      const sourceLineId = nonemptyString3(row.source_line_id);
       const sourceRecordId = sourceMessageId ?? sourceLineId;
       const sourceFields = sourceRecordId ? { sourceRecordId } : {
         sourceOffset: line - 1,
@@ -1503,10 +1504,10 @@ var lettaCodeAdapter = {
         continue;
       }
       const callId = sourceLineId ?? sourceMessageId ?? `letta-code-tool-line-${line}`;
-      const name = nonemptyString4(row.name);
+      const name = nonemptyString3(row.name);
       events.push({
         type: "tool_call",
-        args: nonemptyString4(row.argsText) ?? "{}",
+        args: nonemptyString3(row.argsText) ?? "{}",
         inputLine: line,
         ...sourceFields,
         componentIndex: 0,
@@ -1541,7 +1542,7 @@ var lettaCodeAdapter = {
     };
   }
 };
-function nonemptyString4(value) {
+function nonemptyString3(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function invalidLettaCodeTranscript() {
@@ -1860,9 +1861,9 @@ var openCodeAdapter = {
         continue;
       const info = isObject(message.info) ? message.info : {};
       const role = info.role;
-      const messageId = nonemptyString5(info.id);
+      const messageId = nonemptyString4(info.id);
       const timestamp = parseTimestamp(isObject(info.time) ? info.time.created : undefined);
-      const model = nonemptyString5(info.modelID);
+      const model = nonemptyString4(info.modelID);
       const parts = Array.isArray(message.parts) ? message.parts : [];
       let messageComponentIndex = 0;
       let latestTimestamp;
@@ -1879,7 +1880,7 @@ var openCodeAdapter = {
         const ordinal = partOrdinal++;
         if (!isObject(part))
           continue;
-        const partId = nonemptyString5(part.id);
+        const partId = nonemptyString4(part.id);
         const sourceRecordId = partId ?? messageId;
         let partComponentIndex = 0;
         const emit = (event) => {
@@ -1921,8 +1922,8 @@ var openCodeAdapter = {
           const stateTime = isObject(state.time) ? state.time : {};
           const callTimestamp = orderedTimestamp(parseTimestamp(stateTime.start) ?? timestamp);
           const resultTimestamp = orderedTimestamp(parseTimestamp(stateTime.end) ?? callTimestamp);
-          const callId = nonemptyString5(part.callID);
-          const name = nonemptyString5(part.tool);
+          const callId = nonemptyString4(part.callID);
+          const name = nonemptyString4(part.tool);
           emit({
             type: "tool_call",
             args: jsonString(state.input),
@@ -1931,7 +1932,7 @@ var openCodeAdapter = {
             ...callTimestamp ? { timestamp: callTimestamp } : {},
             ...model ? { model } : {}
           });
-          const status = nonemptyString5(state.status);
+          const status = nonemptyString4(state.status);
           const output = state.output !== undefined ? stringContent2(state.output) : status === "error" ? errorContent(state.error) : undefined;
           if (output !== undefined) {
             emit({
@@ -1953,8 +1954,8 @@ var openCodeAdapter = {
         }
       }
     }
-    const cwd = nonemptyString5(sessionInfo.directory);
-    const sourceGroupId = nonemptyString5(sessionInfo.id);
+    const cwd = nonemptyString4(sessionInfo.directory);
+    const sourceGroupId = nonemptyString4(sessionInfo.id);
     const createdAt = parseTimestamp(isObject(sessionInfo.time) ? sessionInfo.time.created : undefined);
     return {
       events,
@@ -1980,7 +1981,7 @@ function parseOpenCodeDocument(transcript) {
   }
   return parsed;
 }
-function nonemptyString5(value) {
+function nonemptyString4(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function stringContent2(value) {

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -94,6 +94,161 @@ function jsonString(value) {
   return serialized === undefined ? "{}" : serialized;
 }
 
+// src/adapters/atif/index.ts
+var SUPPORTED_SCHEMA_VERSIONS = new Set(Array.from({ length: 8 }, (_, index) => `ATIF-v1.${index}`));
+var atifAdapter = {
+  source: "atif",
+  decode(transcript) {
+    const document = parseAtifDocument(transcript);
+    const diagnostics = [];
+    const events = [];
+    const trajectoryId = nonemptyString(document.trajectory_id);
+    const sessionId = nonemptyString(document.session_id);
+    const rootModel = nonemptyString(document.agent.model_name);
+    for (let index = 0;index < document.steps.length; index += 1) {
+      const step = document.steps[index];
+      if (!isObject(step))
+        throw invalidAtifTranscript();
+      const expectedStepId = index + 1;
+      if (step.step_id !== expectedStepId)
+        throw invalidAtifTranscript();
+      if (step.source !== "system" && step.source !== "user" && step.source !== "agent") {
+        throw invalidAtifTranscript();
+      }
+      if (typeof step.message !== "string" && !Array.isArray(step.message)) {
+        throw invalidAtifTranscript();
+      }
+      const timestamp = parseTimestamp(step.timestamp);
+      const model = step.source === "agent" ? nonemptyString(step.model_name) ?? rootModel : undefined;
+      const sourceRecordId = trajectoryId ? `trajectory:${trajectoryId}:step:${expectedStepId}` : `step:${expectedStepId}`;
+      let componentIndex = 0;
+      const emit = (event) => {
+        events.push({
+          ...event,
+          sourceRecordId,
+          sourceSequence: expectedStepId,
+          componentIndex: componentIndex++
+        });
+      };
+      const shared = {
+        ...timestamp ? { timestamp } : {},
+        ...model ? { model } : {}
+      };
+      if (step.source === "user") {
+        emit({
+          type: "message",
+          role: "user",
+          content: atifContent(step.message),
+          ...shared
+        });
+        continue;
+      }
+      if (step.source === "system") {
+        emit({
+          type: "message",
+          role: "system",
+          content: atifContent(step.message),
+          ...shared
+        });
+      } else {
+        if (typeof step.reasoning_content === "string") {
+          emit({
+            type: "reasoning",
+            content: step.reasoning_content,
+            ...shared
+          });
+        }
+        emit({
+          type: "message",
+          role: "assistant",
+          content: atifContent(step.message),
+          ...shared
+        });
+        if (step.tool_calls != null && !Array.isArray(step.tool_calls)) {
+          throw invalidAtifTranscript();
+        }
+        for (const rawCall of step.tool_calls ?? []) {
+          if (!isObject(rawCall))
+            throw invalidAtifTranscript();
+          const callId = nonemptyString(rawCall.tool_call_id);
+          const name = nonemptyString(rawCall.function_name);
+          emit({
+            type: "tool_call",
+            args: jsonString(rawCall.arguments),
+            ...callId ? { id: callId } : {},
+            ...name ? { name } : {},
+            ...shared
+          });
+        }
+      }
+      if (step.observation == null)
+        continue;
+      if (!isObject(step.observation) || !Array.isArray(step.observation.results)) {
+        throw invalidAtifTranscript();
+      }
+      for (const rawResult of step.observation.results) {
+        if (!isObject(rawResult))
+          throw invalidAtifTranscript();
+        const callId = nonemptyString(rawResult.source_call_id);
+        const content = observationContent(rawResult);
+        emit(callId ? { type: "tool_result", callId, content, ...shared } : { type: "observation", content, ...shared });
+      }
+    }
+    if (Array.isArray(document.subagent_trajectories) && document.subagent_trajectories.length > 0) {
+      diagnostics.push({
+        code: "noise_record_dropped",
+        message: `Did not flatten ${document.subagent_trajectories.length} embedded ATIF subagent trajectory(ies); only root steps are normalized.`,
+        count: document.subagent_trajectories.length
+      });
+    }
+    const createdAt = document.steps.map((step) => isObject(step) ? parseTimestamp(step.timestamp) : undefined).find((value) => value !== undefined);
+    const sourceGroupId = sessionId ?? trajectoryId;
+    return {
+      events,
+      context: {
+        source: "atif",
+        ...rootModel ? { model: rootModel } : {},
+        ...createdAt ? { createdAt } : {},
+        ...sourceGroupId ? { sourceGroupId } : { sourceGroupRequired: true }
+      },
+      diagnostics
+    };
+  }
+};
+function parseAtifDocument(transcript) {
+  let parsed;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidAtifTranscript();
+  }
+  if (!isObject(parsed) || typeof parsed.schema_version !== "string" || !SUPPORTED_SCHEMA_VERSIONS.has(parsed.schema_version) || !isObject(parsed.agent) || typeof parsed.agent.name !== "string" || typeof parsed.agent.version !== "string" || !Array.isArray(parsed.steps) || parsed.steps.length === 0) {
+    throw invalidAtifTranscript();
+  }
+  return parsed;
+}
+function atifContent(value) {
+  if (typeof value === "string")
+    return value;
+  if (Array.isArray(value))
+    return blocksText(value);
+  return jsonString(value);
+}
+function observationContent(result) {
+  if (result.content != null)
+    return atifContent(result.content);
+  if (Array.isArray(result.subagent_trajectory_ref)) {
+    return jsonString({ subagent_trajectory_ref: result.subagent_trajectory_ref });
+  }
+  return "";
+}
+function nonemptyString(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+function invalidAtifTranscript() {
+  return new NormalizationError("invalid_input", "ATIF transcript must be one ATIF-v1.0 through ATIF-v1.7 JSON trajectory object with agent metadata and sequential steps.");
+}
+
 // src/adapters/claude-code/index.ts
 var TRANSPORT_TYPES = new Set([
   "progress",
@@ -515,21 +670,21 @@ var copilotCliAdapter = {
         continue;
       const data = isObject(row.data) ? row.data : {};
       if (row.type === "session.start") {
-        sourceGroupId ??= nonemptyString(data.sessionId);
+        sourceGroupId ??= nonemptyString2(data.sessionId);
         createdAt ??= parseTimestamp(data.startTime);
         const context = isObject(data.context) ? data.context : {};
-        cwd ??= nonemptyString(context.cwd);
-        gitBranch ??= nonemptyString(context.branch);
+        cwd ??= nonemptyString2(context.cwd);
+        gitBranch ??= nonemptyString2(context.branch);
       } else if (row.type === "hook.start" && data.hookType === "userPromptSubmitted") {
         const input = isObject(data.input) ? data.input : {};
-        sourceGroupId ??= nonemptyString(input.sessionId);
-        cwd ??= nonemptyString(input.cwd);
+        sourceGroupId ??= nonemptyString2(input.sessionId);
+        cwd ??= nonemptyString2(input.cwd);
       } else if (row.type === "tool.execution_complete") {
-        model ??= nonemptyString(data.model);
+        model ??= nonemptyString2(data.model);
       } else if (row.type === "session.model_change") {
-        model ??= nonemptyString(data.newModel);
+        model ??= nonemptyString2(data.newModel);
       } else if (row.type === "session.shutdown") {
-        model ??= nonemptyString(data.currentModel);
+        model ??= nonemptyString2(data.currentModel);
       }
     }
     for (const { value: row, line, byteOffset } of rows) {
@@ -545,7 +700,7 @@ var copilotCliAdapter = {
       recognizedRows += 1;
       const data = isObject(row.data) ? row.data : {};
       const timestamp = parseTimestamp(row.timestamp);
-      const sourceRecordId = nonemptyString(row.id);
+      const sourceRecordId = nonemptyString2(row.id);
       let componentIndex = 0;
       const emit = (event) => {
         events.push({
@@ -568,7 +723,7 @@ var copilotCliAdapter = {
         continue;
       }
       if (rowType === "assistant.message") {
-        const eventModel = nonemptyString(data.model);
+        const eventModel = nonemptyString2(data.model);
         if (typeof data.reasoningText === "string" && data.reasoningText.trim()) {
           emit({
             type: "reasoning",
@@ -590,8 +745,8 @@ var copilotCliAdapter = {
           for (const request of data.toolRequests) {
             if (!isObject(request))
               continue;
-            const callId = nonemptyString(request.toolCallId);
-            const name = nonemptyString(request.name);
+            const callId = nonemptyString2(request.toolCallId);
+            const name = nonemptyString2(request.name);
             emit({
               type: "tool_call",
               args: typeof request.arguments === "string" ? request.arguments : jsonString(request.arguments),
@@ -605,8 +760,8 @@ var copilotCliAdapter = {
         continue;
       }
       if (rowType === "tool.execution_complete") {
-        const callId = nonemptyString(data.toolCallId);
-        const eventModel = nonemptyString(data.model);
+        const callId = nonemptyString2(data.toolCallId);
+        const eventModel = nonemptyString2(data.model);
         emit({
           type: "tool_result",
           content: copilotResultContent(data),
@@ -633,7 +788,7 @@ var copilotCliAdapter = {
     };
   }
 };
-function nonemptyString(value) {
+function nonemptyString2(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function copilotResultContent(data) {
@@ -867,8 +1022,8 @@ var geminiCliAdapter = {
       if (messageType === "info")
         continue;
       const timestamp = parseTimestamp(message.timestamp);
-      const model = nonemptyString2(message.model);
-      const sourceRecordId = nonemptyString2(message.id);
+      const model = nonemptyString3(message.model);
+      const sourceRecordId = nonemptyString3(message.id);
       let componentIndex = 0;
       const emit = (event) => {
         events.push({
@@ -922,8 +1077,8 @@ var geminiCliAdapter = {
       for (const rawCall of message.toolCalls) {
         if (!isObject(rawCall))
           continue;
-        const callId = nonemptyString2(rawCall.id);
-        const name = nonemptyString2(rawCall.name);
+        const callId = nonemptyString3(rawCall.id);
+        const name = nonemptyString3(rawCall.name);
         const callTimestamp = parseTimestamp(rawCall.timestamp) ?? timestamp;
         emit({
           type: "tool_call",
@@ -933,7 +1088,7 @@ var geminiCliAdapter = {
           ...callTimestamp ? { timestamp: callTimestamp } : {},
           ...model ? { model } : {}
         });
-        const status = nonemptyString2(rawCall.status);
+        const status = nonemptyString3(rawCall.status);
         const outputs = toolOutputs(rawCall.result);
         if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
           continue;
@@ -949,8 +1104,8 @@ var geminiCliAdapter = {
         });
       }
     }
-    const sourceGroupId = nonemptyString2(document.sessionId);
-    const sourceGroupRequired = !sourceGroupId && !nonemptyString2(document.projectHash);
+    const sourceGroupId = nonemptyString3(document.sessionId);
+    const sourceGroupRequired = !sourceGroupId && !nonemptyString3(document.projectHash);
     const createdAt = parseTimestamp(document.startTime);
     return {
       events,
@@ -976,7 +1131,7 @@ function parseGeminiDocument(transcript) {
   }
   return parsed;
 }
-function nonemptyString2(value) {
+function nonemptyString3(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function thoughtContent(value) {
@@ -1285,7 +1440,7 @@ var lettaCodeAdapter = {
     for (const { value: row } of rows) {
       if (row.kind !== "reasoning")
         continue;
-      const sourceRecordId = nonemptyString3(row.source_message_id) ?? nonemptyString3(row.source_line_id);
+      const sourceRecordId = nonemptyString4(row.source_message_id) ?? nonemptyString4(row.source_line_id);
       if (sourceRecordId)
         reasoningRecordIds.add(sourceRecordId);
     }
@@ -1308,8 +1463,8 @@ var lettaCodeAdapter = {
         continue;
       }
       const timestamp = parseTimestamp(row.captured_at);
-      const sourceMessageId = nonemptyString3(row.source_message_id);
-      const sourceLineId = nonemptyString3(row.source_line_id);
+      const sourceMessageId = nonemptyString4(row.source_message_id);
+      const sourceLineId = nonemptyString4(row.source_line_id);
       const sourceRecordId = sourceMessageId ?? sourceLineId;
       const sourceFields = sourceRecordId ? { sourceRecordId } : {
         sourceOffset: line - 1,
@@ -1348,10 +1503,10 @@ var lettaCodeAdapter = {
         continue;
       }
       const callId = sourceLineId ?? sourceMessageId ?? `letta-code-tool-line-${line}`;
-      const name = nonemptyString3(row.name);
+      const name = nonemptyString4(row.name);
       events.push({
         type: "tool_call",
-        args: nonemptyString3(row.argsText) ?? "{}",
+        args: nonemptyString4(row.argsText) ?? "{}",
         inputLine: line,
         ...sourceFields,
         componentIndex: 0,
@@ -1386,7 +1541,7 @@ var lettaCodeAdapter = {
     };
   }
 };
-function nonemptyString3(value) {
+function nonemptyString4(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function invalidLettaCodeTranscript() {
@@ -1705,9 +1860,9 @@ var openCodeAdapter = {
         continue;
       const info = isObject(message.info) ? message.info : {};
       const role = info.role;
-      const messageId = nonemptyString4(info.id);
+      const messageId = nonemptyString5(info.id);
       const timestamp = parseTimestamp(isObject(info.time) ? info.time.created : undefined);
-      const model = nonemptyString4(info.modelID);
+      const model = nonemptyString5(info.modelID);
       const parts = Array.isArray(message.parts) ? message.parts : [];
       let messageComponentIndex = 0;
       let latestTimestamp;
@@ -1724,7 +1879,7 @@ var openCodeAdapter = {
         const ordinal = partOrdinal++;
         if (!isObject(part))
           continue;
-        const partId = nonemptyString4(part.id);
+        const partId = nonemptyString5(part.id);
         const sourceRecordId = partId ?? messageId;
         let partComponentIndex = 0;
         const emit = (event) => {
@@ -1766,8 +1921,8 @@ var openCodeAdapter = {
           const stateTime = isObject(state.time) ? state.time : {};
           const callTimestamp = orderedTimestamp(parseTimestamp(stateTime.start) ?? timestamp);
           const resultTimestamp = orderedTimestamp(parseTimestamp(stateTime.end) ?? callTimestamp);
-          const callId = nonemptyString4(part.callID);
-          const name = nonemptyString4(part.tool);
+          const callId = nonemptyString5(part.callID);
+          const name = nonemptyString5(part.tool);
           emit({
             type: "tool_call",
             args: jsonString(state.input),
@@ -1776,7 +1931,7 @@ var openCodeAdapter = {
             ...callTimestamp ? { timestamp: callTimestamp } : {},
             ...model ? { model } : {}
           });
-          const status = nonemptyString4(state.status);
+          const status = nonemptyString5(state.status);
           const output = state.output !== undefined ? stringContent2(state.output) : status === "error" ? errorContent(state.error) : undefined;
           if (output !== undefined) {
             emit({
@@ -1798,8 +1953,8 @@ var openCodeAdapter = {
         }
       }
     }
-    const cwd = nonemptyString4(sessionInfo.directory);
-    const sourceGroupId = nonemptyString4(sessionInfo.id);
+    const cwd = nonemptyString5(sessionInfo.directory);
+    const sourceGroupId = nonemptyString5(sessionInfo.id);
     const createdAt = parseTimestamp(isObject(sessionInfo.time) ? sessionInfo.time.created : undefined);
     return {
       events,
@@ -1825,7 +1980,7 @@ function parseOpenCodeDocument(transcript) {
   }
   return parsed;
 }
-function nonemptyString4(value) {
+function nonemptyString5(value) {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function stringContent2(value) {
@@ -3400,7 +3555,7 @@ async function listTrajectories(input) {
   return paginate(items, input.cursor, limit);
 }
 function isKnownNormalizationOnlySource(source) {
-  return source === "copilot-cli" || source === "cursor" || source === "gemini-cli" || source === "opencode";
+  return source === "atif" || source === "copilot-cli" || source === "cursor" || source === "gemini-cli" || source === "opencode";
 }
 function resolveLimit2(limit) {
   if (limit === undefined)
@@ -3449,6 +3604,7 @@ function invalidCursor() {
 
 // src/index.ts
 var ADAPTERS = {
+  atif: atifAdapter,
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   "copilot-cli": copilotCliAdapter,

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -23,6 +23,8 @@ try:
 except ModuleNotFoundError:
     HAS_LANGGRAPH_SQLITE = False
 FIXTURES = (
+    ("atif", "atif/tool-calls", "input.json"),
+    ("atif", "atif/cleanup", "input.json"),
     ("claude-code", "claude-code/tool-call", "input.jsonl"),
     ("claude-code", "claude-code/cleanup", "input.jsonl"),
     ("codex", "codex/tool-calls", "input.jsonl"),

--- a/src/adapters/atif/README.md
+++ b/src/adapters/atif/README.md
@@ -1,0 +1,29 @@
+# atif
+
+One complete [Agent Trajectory Interchange Format (ATIF)](https://github.com/harbor-framework/harbor/blob/main/rfcs/0001-trajectory-format.md)
+JSON trajectory document. The adapter accepts schema versions `ATIF-v1.0`
+through `ATIF-v1.7`; locating and reading `trajectory.json` remains the
+caller's responsibility.
+
+Root `steps` are decoded in `step_id` order. User and agent messages, agent
+`reasoning_content`, tool calls, same-step observation results, timestamps,
+and model metadata are preserved. System messages are available through
+`filters.systemMessages: "include"` and omitted by default. Observation results
+without `source_call_id` become generic `observation` records rather than being
+assigned to an arbitrary tool call. `session_id` supplies run identity;
+`trajectory_id` is used when a session ID is absent and also namespaces native
+step identity. Canonical normalization requires `sourceContext.groupId` when
+both identifiers are absent. Text content parts are joined with newlines and
+image parts are represented as `[image]`, matching the other multimodal
+adapters.
+
+Embedded `subagent_trajectories` are not flattened into the parent timeline;
+normalize each embedded trajectory separately when its records are needed. A
+tool-linked result containing only `subagent_trajectory_ref` is retained as a
+JSON string. Metrics, token IDs, logprobs, costs, notes, custom `extra` fields,
+tool definitions, `is_copied_context`, `llm_call_count`, and continuation
+references have no target fields and are not emitted. ATIF observation results
+also have no standard success field, so normalized tool results omit `ok`.
+
+ATIF is an exported interchange document, not a standard local agent store, so
+`listTrajectories({ source: "atif" })` returns `listing_unavailable`.

--- a/src/adapters/atif/index.ts
+++ b/src/adapters/atif/index.ts
@@ -23,9 +23,10 @@ export const atifAdapter: SourceAdapter = {
     const document = parseAtifDocument(transcript);
     const diagnostics: Diagnostic[] = [];
     const events: DecodedEvent[] = [];
-    const trajectoryId = nonemptyString(document.trajectory_id);
-    const sessionId = nonemptyString(document.session_id);
-    const rootModel = nonemptyString(document.agent.model_name);
+    const trajectoryId = atifNonemptyString(document.trajectory_id);
+    const sessionId = atifNonemptyString(document.session_id);
+    const rootModel = atifNonemptyString(document.agent.model_name);
+    let createdAt: Date | undefined;
 
     for (let index = 0; index < document.steps.length; index += 1) {
       const step = document.steps[index];
@@ -44,9 +45,10 @@ export const atifAdapter: SourceAdapter = {
       }
 
       const timestamp = parseTimestamp(step.timestamp);
+      createdAt ??= timestamp;
       const model =
         step.source === "agent"
-          ? nonemptyString(step.model_name) ?? rootModel
+          ? atifNonemptyString(step.model_name) ?? rootModel
           : undefined;
       const sourceRecordId = trajectoryId
         ? `trajectory:${trajectoryId}:step:${expectedStepId}`
@@ -102,8 +104,8 @@ export const atifAdapter: SourceAdapter = {
         }
         for (const rawCall of step.tool_calls ?? []) {
           if (!isObject(rawCall)) throw invalidAtifTranscript();
-          const callId = nonemptyString(rawCall.tool_call_id);
-          const name = nonemptyString(rawCall.function_name);
+          const callId = atifNonemptyString(rawCall.tool_call_id);
+          const name = atifNonemptyString(rawCall.function_name);
           emit({
             type: "tool_call",
             args: jsonString(rawCall.arguments),
@@ -120,7 +122,7 @@ export const atifAdapter: SourceAdapter = {
       }
       for (const rawResult of step.observation.results) {
         if (!isObject(rawResult)) throw invalidAtifTranscript();
-        const callId = nonemptyString(rawResult.source_call_id);
+        const callId = atifNonemptyString(rawResult.source_call_id);
         const content = observationContent(rawResult);
         emit(
           callId
@@ -141,9 +143,6 @@ export const atifAdapter: SourceAdapter = {
       });
     }
 
-    const createdAt = document.steps
-      .map((step) => (isObject(step) ? parseTimestamp(step.timestamp) : undefined))
-      .find((value): value is Date => value !== undefined);
     const sourceGroupId = sessionId ?? trajectoryId;
     return {
       events,
@@ -199,7 +198,7 @@ function observationContent(result: Record<string, unknown>): string {
   return "";
 }
 
-function nonemptyString(value: unknown): string | undefined {
+function atifNonemptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 

--- a/src/adapters/atif/index.ts
+++ b/src/adapters/atif/index.ts
@@ -1,0 +1,211 @@
+import type {
+  DecodedEvent,
+  DecodedSession,
+  SourceAdapter,
+} from "../../internal.js";
+import type { Diagnostic } from "../../types.js";
+import { NormalizationError } from "../../types.js";
+import {
+  blocksText,
+  isObject,
+  jsonString,
+  parseTimestamp,
+} from "../shared.js";
+
+const SUPPORTED_SCHEMA_VERSIONS = new Set(
+  Array.from({ length: 8 }, (_, index) => `ATIF-v1.${index}`),
+);
+
+export const atifAdapter: SourceAdapter = {
+  source: "atif",
+
+  decode(transcript: string): DecodedSession {
+    const document = parseAtifDocument(transcript);
+    const diagnostics: Diagnostic[] = [];
+    const events: DecodedEvent[] = [];
+    const trajectoryId = nonemptyString(document.trajectory_id);
+    const sessionId = nonemptyString(document.session_id);
+    const rootModel = nonemptyString(document.agent.model_name);
+
+    for (let index = 0; index < document.steps.length; index += 1) {
+      const step = document.steps[index];
+      if (!isObject(step)) throw invalidAtifTranscript();
+      const expectedStepId = index + 1;
+      if (step.step_id !== expectedStepId) throw invalidAtifTranscript();
+      if (
+        step.source !== "system" &&
+        step.source !== "user" &&
+        step.source !== "agent"
+      ) {
+        throw invalidAtifTranscript();
+      }
+      if (typeof step.message !== "string" && !Array.isArray(step.message)) {
+        throw invalidAtifTranscript();
+      }
+
+      const timestamp = parseTimestamp(step.timestamp);
+      const model =
+        step.source === "agent"
+          ? nonemptyString(step.model_name) ?? rootModel
+          : undefined;
+      const sourceRecordId = trajectoryId
+        ? `trajectory:${trajectoryId}:step:${expectedStepId}`
+        : `step:${expectedStepId}`;
+      let componentIndex = 0;
+      const emit = (event: DecodedEvent): void => {
+        events.push({
+          ...event,
+          sourceRecordId,
+          sourceSequence: expectedStepId,
+          componentIndex: componentIndex++,
+        });
+      };
+      const shared = {
+        ...(timestamp ? { timestamp } : {}),
+        ...(model ? { model } : {}),
+      };
+
+      if (step.source === "user") {
+        emit({
+          type: "message",
+          role: "user",
+          content: atifContent(step.message),
+          ...shared,
+        });
+        continue;
+      }
+
+      if (step.source === "system") {
+        emit({
+          type: "message",
+          role: "system",
+          content: atifContent(step.message),
+          ...shared,
+        });
+      } else {
+        if (typeof step.reasoning_content === "string") {
+          emit({
+            type: "reasoning",
+            content: step.reasoning_content,
+            ...shared,
+          });
+        }
+        emit({
+          type: "message",
+          role: "assistant",
+          content: atifContent(step.message),
+          ...shared,
+        });
+
+        if (step.tool_calls != null && !Array.isArray(step.tool_calls)) {
+          throw invalidAtifTranscript();
+        }
+        for (const rawCall of step.tool_calls ?? []) {
+          if (!isObject(rawCall)) throw invalidAtifTranscript();
+          const callId = nonemptyString(rawCall.tool_call_id);
+          const name = nonemptyString(rawCall.function_name);
+          emit({
+            type: "tool_call",
+            args: jsonString(rawCall.arguments),
+            ...(callId ? { id: callId } : {}),
+            ...(name ? { name } : {}),
+            ...shared,
+          });
+        }
+      }
+
+      if (step.observation == null) continue;
+      if (!isObject(step.observation) || !Array.isArray(step.observation.results)) {
+        throw invalidAtifTranscript();
+      }
+      for (const rawResult of step.observation.results) {
+        if (!isObject(rawResult)) throw invalidAtifTranscript();
+        const callId = nonemptyString(rawResult.source_call_id);
+        const content = observationContent(rawResult);
+        emit(
+          callId
+            ? { type: "tool_result", callId, content, ...shared }
+            : { type: "observation", content, ...shared },
+        );
+      }
+    }
+
+    if (
+      Array.isArray(document.subagent_trajectories) &&
+      document.subagent_trajectories.length > 0
+    ) {
+      diagnostics.push({
+        code: "noise_record_dropped",
+        message: `Did not flatten ${document.subagent_trajectories.length} embedded ATIF subagent trajectory(ies); only root steps are normalized.`,
+        count: document.subagent_trajectories.length,
+      });
+    }
+
+    const createdAt = document.steps
+      .map((step) => (isObject(step) ? parseTimestamp(step.timestamp) : undefined))
+      .find((value): value is Date => value !== undefined);
+    const sourceGroupId = sessionId ?? trajectoryId;
+    return {
+      events,
+      context: {
+        source: "atif",
+        ...(rootModel ? { model: rootModel } : {}),
+        ...(createdAt ? { createdAt } : {}),
+        ...(sourceGroupId ? { sourceGroupId } : { sourceGroupRequired: true }),
+      },
+      diagnostics,
+    };
+  },
+};
+
+interface AtifDocument extends Record<string, unknown> {
+  agent: Record<string, unknown>;
+  steps: unknown[];
+}
+
+function parseAtifDocument(transcript: string): AtifDocument {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    throw invalidAtifTranscript();
+  }
+  if (
+    !isObject(parsed) ||
+    typeof parsed.schema_version !== "string" ||
+    !SUPPORTED_SCHEMA_VERSIONS.has(parsed.schema_version) ||
+    !isObject(parsed.agent) ||
+    typeof parsed.agent.name !== "string" ||
+    typeof parsed.agent.version !== "string" ||
+    !Array.isArray(parsed.steps) ||
+    parsed.steps.length === 0
+  ) {
+    throw invalidAtifTranscript();
+  }
+  return parsed as AtifDocument;
+}
+
+function atifContent(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return blocksText(value);
+  return jsonString(value);
+}
+
+function observationContent(result: Record<string, unknown>): string {
+  if (result.content != null) return atifContent(result.content);
+  if (Array.isArray(result.subagent_trajectory_ref)) {
+    return jsonString({ subagent_trajectory_ref: result.subagent_trajectory_ref });
+  }
+  return "";
+}
+
+function nonemptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function invalidAtifTranscript(): NormalizationError {
+  return new NormalizationError(
+    "invalid_input",
+    "ATIF transcript must be one ATIF-v1.0 through ATIF-v1.7 JSON trajectory object with agent metadata and sequential steps.",
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { atifAdapter } from "./adapters/atif/index.js";
 import { claudeCodeAdapter } from "./adapters/claude-code/index.js";
 import { codexAdapter } from "./adapters/codex/index.js";
 import { copilotCliAdapter } from "./adapters/copilot-cli/index.js";
@@ -30,6 +31,7 @@ import type {
 import { NormalizationError } from "./types.js";
 
 const ADAPTERS: Record<TranscriptTrajectorySource, SourceAdapter> = {
+  atif: atifAdapter,
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   "copilot-cli": copilotCliAdapter,

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -111,6 +111,7 @@ export async function listTrajectories(
 
 function isKnownNormalizationOnlySource(source: AnyTrajectorySource): boolean {
   return (
+    source === "atif" ||
     source === "copilot-cli" ||
     source === "cursor" ||
     source === "gemini-cli" ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { ResolvedNormalizationBounds } from "./bounds.js";
 import type { ResolvedNormalizationFilters } from "./filters.js";
 
 export type TrajectorySource =
+  | "atif"
   | "claude-code"
   | "codex"
   | "copilot-cli"

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -41,6 +41,7 @@ const goldenFixtures = [
 }>;
 
 const additionalInvariantFixtures = [
+  { source: "atif", name: "atif/tool-calls" },
   { source: "copilot-cli", name: "copilot-cli/tool-calls" },
   { source: "cursor", name: "cursor/tool-calls" },
   { source: "gemini-cli", name: "gemini-cli/tool-calls" },
@@ -79,6 +80,7 @@ describe("canonical invariants", () => {
   for (const fixture of [...goldenFixtures, ...additionalInvariantFixtures]) {
     test(fixture.name, () => {
       const inputFile =
+        fixture.source === "atif" ||
         fixture.source === "openhands" ||
         fixture.source === "hermes" ||
         fixture.source === "gemini-cli" ||
@@ -122,7 +124,9 @@ describe("new source-native identity", () => {
   )) {
     test(fixture.source, () => {
       const inputFile =
-        fixture.source === "gemini-cli" || fixture.source === "opencode"
+        fixture.source === "atif" ||
+        fixture.source === "gemini-cli" ||
+        fixture.source === "opencode"
           ? "input.json"
           : "input.jsonl";
       const result = normalizeToCanonical({
@@ -179,6 +183,48 @@ describe("new source-native identity", () => {
     expect(new Set(result.records.map((record) => record.source_group_id))).toEqual(
       new Set(["messages-only-export"]),
     );
+  });
+
+  test("ATIF documents without run or trajectory identity require an explicit canonical group", () => {
+    const transcript = JSON.stringify({
+      schema_version: "ATIF-v1.7",
+      agent: { name: "agent", version: "1" },
+      steps: [
+        { step_id: 1, source: "user", message: "Inspect it." },
+        { step_id: 2, source: "agent", message: "I inspected it." },
+      ],
+    });
+
+    expect(() => normalizeToCanonical({ source: "atif", transcript })).toThrow(
+      expect.objectContaining({ code: "source_group_required" }),
+    );
+    const result = normalizeToCanonical({
+      source: "atif",
+      transcript,
+      sourceContext: { groupId: "atif-import" },
+    });
+    expect(new Set(result.records.map((record) => record.source_group_id))).toEqual(
+      new Set(["atif-import"]),
+    );
+  });
+
+  test("ATIF preserves native identity for system and generic observation records", () => {
+    const result = normalizeToCanonical({
+      source: "atif",
+      transcript: fixtureText("atif/cleanup", "input.json"),
+      filters: { systemMessages: "include" },
+    });
+
+    for (const recordType of ["system", "observation"] as const) {
+      const record = result.records.find((item) => item.record_type === recordType);
+      expect(record).toMatchObject({
+        source_type: "atif",
+        source_identity_kind: "native",
+        record_type: recordType,
+      });
+      expect(record?.record_id).toMatch(HEX_64);
+    }
+    expect(validateCanonical(result.records)).toBe(true);
   });
 
   test("Gemini CLI projectHash-only exports retain the default canonical group", () => {

--- a/test/listing.test.ts
+++ b/test/listing.test.ts
@@ -128,6 +128,7 @@ afterAll(() => {
 describe("listTrajectories", () => {
   test("reports normalization-only sources without pretending to discover a store", async () => {
     for (const source of [
+      "atif",
       "copilot-cli",
       "cursor",
       "gemini-cli",

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -11,6 +11,8 @@ import {
 import type { NormalizeResult, TrajectorySource } from "../src/index.js";
 
 const fixtures = [
+  { source: "atif", name: "atif/tool-calls" },
+  { source: "atif", name: "atif/cleanup" },
   { source: "claude-code", name: "claude-code/tool-call" },
   { source: "claude-code", name: "claude-code/cleanup" },
   { source: "claude-code", name: "claude-code/subagent" },
@@ -56,7 +58,8 @@ describe("golden fixtures", () => {
     test(fixture.name, () => {
       const input = fixtureText(
         fixture.name,
-        fixture.source === "openhands" ||
+        fixture.source === "atif" ||
+          fixture.source === "openhands" ||
           fixture.source === "hermes" ||
           fixture.source === "gemini-cli" ||
           fixture.source === "opencode"
@@ -383,6 +386,74 @@ describe("public API", () => {
     );
   });
 
+  test("rejects malformed or unsupported ATIF documents", () => {
+    for (const transcript of [
+      "not json",
+      JSON.stringify({ schema_version: "ATIF-v1.8", agent: {}, steps: [] }),
+      JSON.stringify({
+        schema_version: "ATIF-v1.7",
+        agent: { name: "agent", version: "1" },
+        steps: [],
+      }),
+      JSON.stringify({
+        schema_version: "ATIF-v1.7",
+        agent: { name: "agent", version: "1" },
+        steps: [{ step_id: 2, source: "user", message: "out of order" }],
+      }),
+    ]) {
+      expect(() => normalizeTranscript({ source: "atif", transcript })).toThrow(
+        expect.objectContaining({ code: "invalid_input" }),
+      );
+    }
+  });
+
+  test("accepts every published ATIF v1 schema version", () => {
+    for (let minor = 0; minor <= 7; minor += 1) {
+      const result = normalizeTranscript({
+        source: "atif",
+        transcript: JSON.stringify({
+          schema_version: `ATIF-v1.${minor}`,
+          session_id: `atif-v1.${minor}`,
+          agent: { name: "agent", version: "1" },
+          steps: [
+            { step_id: 1, source: "user", message: "hello" },
+            { step_id: 2, source: "agent", message: "hi" },
+          ],
+        }),
+      });
+
+      expect(result.records.map((record) => record.role)).toEqual([
+        "meta",
+        "user",
+        "assistant",
+      ]);
+    }
+  });
+
+  test("preserves ATIF system and unlinked observation semantics", () => {
+    const transcript = fixtureText("atif/cleanup", "input.json");
+    const defaultResult = normalizeTranscript({ source: "atif", transcript });
+    expect(defaultResult.records.some((record) => record.role === "system")).toBe(
+      false,
+    );
+    expect(defaultResult.records).toContainEqual({
+      role: "observation",
+      content: "Environment reset complete.",
+      timestamp: "2026-08-18T11:00:02.000Z",
+    });
+
+    const included = normalizeTranscript({
+      source: "atif",
+      transcript,
+      filters: { systemMessages: "include" },
+    });
+    expect(included.records).toContainEqual({
+      role: "system",
+      content: "Use the provided tools.",
+      timestamp: "2026-08-18T11:00:00.000Z",
+    });
+  });
+
   test("rejects a transcript without a user turn", () => {
     const transcript = JSON.stringify({
       type: "response_item",
@@ -570,7 +641,8 @@ describe("public API", () => {
     test(`omits tool results while retaining calls for ${fixture.source}`, () => {
       const input = fixtureText(
         fixture.name,
-        fixture.source === "openhands" ||
+        fixture.source === "atif" ||
+          fixture.source === "openhands" ||
           fixture.source === "hermes" ||
           fixture.source === "gemini-cli" ||
           fixture.source === "opencode"


### PR DESCRIPTION
## Summary
- add `normalizeTranscript({ source: "atif", transcript })` for ATIF-v1.0 through ATIF-v1.7 trajectory JSON
- preserve messages, reasoning, tool calls, linked results, generic observations, timestamps, models, and source-native step identity
- expose system messages only through `filters.systemMessages: "include"`
- require an explicit canonical group only when both `session_id` and `trajectory_id` are absent
- add TypeScript/Python parity, fixtures, listing behavior, adapter docs, and corpus audit results

## Corpus validation
Privacy-safe aggregate validation covered 3,373 Harbor trajectories (499,643,224 bytes) from eight producers:
- strict normalization: 2,583 passed; 790 correctly failed shared whole-transcript invariants
- partial normalization: 3,373 passed, 311,712 records
- explicit system inclusion: 312,321 records
- canonical normalization: 3,373 passed, 308,339 native body identities, zero duplicate record IDs within a trajectory
- preserved all 33,845 unlinked observation results as generic observations

## Validation
- `bun run check` (178 passed, 7 dependency-gated skips)
- `PYTHONPATH=python/src python3.12 -m unittest discover -s python/tests -v` (11 passed, 1 dependency-gated skip)
- built-package smoke test
- `npm pack --dry-run`
- credential-pattern scan
- `git diff --check`