### PR TITLE
refactor: share non-empty string parsing

### DIFF
--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -55,6 +55,9 @@ function utf8ByteLength(text) {
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
+function nonemptyString(value) {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 function parseTimestamp(value) {
   if (value instanceof Date && !Number.isNaN(value.getTime()))
     return value;
@@ -102,9 +105,9 @@ var atifAdapter = {
     const document = parseAtifDocument(transcript);
     const diagnostics = [];
     const events = [];
-    const trajectoryId = atifNonemptyString(document.trajectory_id);
-    const sessionId = atifNonemptyString(document.session_id);
-    const rootModel = atifNonemptyString(document.agent.model_name);
+    const trajectoryId = nonemptyString(document.trajectory_id);
+    const sessionId = nonemptyString(document.session_id);
+    const rootModel = nonemptyString(document.agent.model_name);
     let createdAt;
     for (let index = 0;index < document.steps.length; index += 1) {
       const step = document.steps[index];
@@ -121,7 +124,7 @@ var atifAdapter = {
       }
       const timestamp = parseTimestamp(step.timestamp);
       createdAt ??= timestamp;
-      const model = step.source === "agent" ? atifNonemptyString(step.model_name) ?? rootModel : undefined;
+      const model = step.source === "agent" ? nonemptyString(step.model_name) ?? rootModel : undefined;
       const sourceRecordId = trajectoryId ? `trajectory:${trajectoryId}:step:${expectedStepId}` : `step:${expectedStepId}`;
       let componentIndex = 0;
       const emit = (event) => {
@@ -172,8 +175,8 @@ var atifAdapter = {
         for (const rawCall of step.tool_calls ?? []) {
           if (!isObject(rawCall))
             throw invalidAtifTranscript();
-          const callId = atifNonemptyString(rawCall.tool_call_id);
-          const name = atifNonemptyString(rawCall.function_name);
+          const callId = nonemptyString(rawCall.tool_call_id);
+          const name = nonemptyString(rawCall.function_name);
           emit({
             type: "tool_call",
             args: jsonString(rawCall.arguments),
@@ -191,7 +194,7 @@ var atifAdapter = {
       for (const rawResult of step.observation.results) {
         if (!isObject(rawResult))
           throw invalidAtifTranscript();
-        const callId = atifNonemptyString(rawResult.source_call_id);
+        const callId = nonemptyString(rawResult.source_call_id);
         const content = observationContent(rawResult);
         emit(callId ? { type: "tool_result", callId, content, ...shared } : { type: "observation", content, ...shared });
       }
@@ -242,9 +245,6 @@ function observationContent(result) {
     return jsonString({ subagent_trajectory_ref: result.subagent_trajectory_ref });
   }
   return "";
-}
-function atifNonemptyString(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function invalidAtifTranscript() {
   return new NormalizationError("invalid_input", "ATIF transcript must be one ATIF-v1.0 through ATIF-v1.7 JSON trajectory object with agent metadata and sequential steps.");
@@ -789,9 +789,6 @@ var copilotCliAdapter = {
     };
   }
 };
-function nonemptyString(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
 function copilotResultContent(data) {
   if (isObject(data.result)) {
     const content = data.result.content;
@@ -1023,8 +1020,8 @@ var geminiCliAdapter = {
       if (messageType === "info")
         continue;
       const timestamp = parseTimestamp(message.timestamp);
-      const model = nonemptyString2(message.model);
-      const sourceRecordId = nonemptyString2(message.id);
+      const model = nonemptyString(message.model);
+      const sourceRecordId = nonemptyString(message.id);
       let componentIndex = 0;
       const emit = (event) => {
         events.push({
@@ -1078,8 +1075,8 @@ var geminiCliAdapter = {
       for (const rawCall of message.toolCalls) {
         if (!isObject(rawCall))
           continue;
-        const callId = nonemptyString2(rawCall.id);
-        const name = nonemptyString2(rawCall.name);
+        const callId = nonemptyString(rawCall.id);
+        const name = nonemptyString(rawCall.name);
         const callTimestamp = parseTimestamp(rawCall.timestamp) ?? timestamp;
         emit({
           type: "tool_call",
@@ -1089,7 +1086,7 @@ var geminiCliAdapter = {
           ...callTimestamp ? { timestamp: callTimestamp } : {},
           ...model ? { model } : {}
         });
-        const status = nonemptyString2(rawCall.status);
+        const status = nonemptyString(rawCall.status);
         const outputs = toolOutputs(rawCall.result);
         if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
           continue;
@@ -1105,8 +1102,8 @@ var geminiCliAdapter = {
         });
       }
     }
-    const sourceGroupId = nonemptyString2(document.sessionId);
-    const sourceGroupRequired = !sourceGroupId && !nonemptyString2(document.projectHash);
+    const sourceGroupId = nonemptyString(document.sessionId);
+    const sourceGroupRequired = !sourceGroupId && !nonemptyString(document.projectHash);
     const createdAt = parseTimestamp(document.startTime);
     return {
       events,
@@ -1131,9 +1128,6 @@ function parseGeminiDocument(transcript) {
     throw invalidGeminiTranscript();
   }
   return parsed;
-}
-function nonemptyString2(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function thoughtContent(value) {
   if (!isObject(value))
@@ -1441,7 +1435,7 @@ var lettaCodeAdapter = {
     for (const { value: row } of rows) {
       if (row.kind !== "reasoning")
         continue;
-      const sourceRecordId = nonemptyString3(row.source_message_id) ?? nonemptyString3(row.source_line_id);
+      const sourceRecordId = nonemptyString(row.source_message_id) ?? nonemptyString(row.source_line_id);
       if (sourceRecordId)
         reasoningRecordIds.add(sourceRecordId);
     }
@@ -1464,8 +1458,8 @@ var lettaCodeAdapter = {
         continue;
       }
       const timestamp = parseTimestamp(row.captured_at);
-      const sourceMessageId = nonemptyString3(row.source_message_id);
-      const sourceLineId = nonemptyString3(row.source_line_id);
+      const sourceMessageId = nonemptyString(row.source_message_id);
+      const sourceLineId = nonemptyString(row.source_line_id);
       const sourceRecordId = sourceMessageId ?? sourceLineId;
       const sourceFields = sourceRecordId ? { sourceRecordId } : {
         sourceOffset: line - 1,
@@ -1504,10 +1498,10 @@ var lettaCodeAdapter = {
         continue;
       }
       const callId = sourceLineId ?? sourceMessageId ?? `letta-code-tool-line-${line}`;
-      const name = nonemptyString3(row.name);
+      const name = nonemptyString(row.name);
       events.push({
         type: "tool_call",
-        args: nonemptyString3(row.argsText) ?? "{}",
+        args: nonemptyString(row.argsText) ?? "{}",
         inputLine: line,
         ...sourceFields,
         componentIndex: 0,
@@ -1542,9 +1536,6 @@ var lettaCodeAdapter = {
     };
   }
 };
-function nonemptyString3(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
 function invalidLettaCodeTranscript() {
   return new NormalizationError("invalid_input", "Letta Code transcript must be client-side transcript.jsonl with kind-tagged rows.");
 }
@@ -1861,9 +1852,9 @@ var openCodeAdapter = {
         continue;
       const info = isObject(message.info) ? message.info : {};
       const role = info.role;
-      const messageId = nonemptyString4(info.id);
+      const messageId = nonemptyString(info.id);
       const timestamp = parseTimestamp(isObject(info.time) ? info.time.created : undefined);
-      const model = nonemptyString4(info.modelID);
+      const model = nonemptyString(info.modelID);
       const parts = Array.isArray(message.parts) ? message.parts : [];
       let messageComponentIndex = 0;
       let latestTimestamp;
@@ -1880,7 +1871,7 @@ var openCodeAdapter = {
         const ordinal = partOrdinal++;
         if (!isObject(part))
           continue;
-        const partId = nonemptyString4(part.id);
+        const partId = nonemptyString(part.id);
         const sourceRecordId = partId ?? messageId;
         let partComponentIndex = 0;
         const emit = (event) => {
@@ -1922,8 +1913,8 @@ var openCodeAdapter = {
           const stateTime = isObject(state.time) ? state.time : {};
           const callTimestamp = orderedTimestamp(parseTimestamp(stateTime.start) ?? timestamp);
           const resultTimestamp = orderedTimestamp(parseTimestamp(stateTime.end) ?? callTimestamp);
-          const callId = nonemptyString4(part.callID);
-          const name = nonemptyString4(part.tool);
+          const callId = nonemptyString(part.callID);
+          const name = nonemptyString(part.tool);
           emit({
             type: "tool_call",
             args: jsonString(state.input),
@@ -1932,7 +1923,7 @@ var openCodeAdapter = {
             ...callTimestamp ? { timestamp: callTimestamp } : {},
             ...model ? { model } : {}
           });
-          const status = nonemptyString4(state.status);
+          const status = nonemptyString(state.status);
           const output = state.output !== undefined ? stringContent2(state.output) : status === "error" ? errorContent(state.error) : undefined;
           if (output !== undefined) {
             emit({
@@ -1954,8 +1945,8 @@ var openCodeAdapter = {
         }
       }
     }
-    const cwd = nonemptyString4(sessionInfo.directory);
-    const sourceGroupId = nonemptyString4(sessionInfo.id);
+    const cwd = nonemptyString(sessionInfo.directory);
+    const sourceGroupId = nonemptyString(sessionInfo.id);
     const createdAt = parseTimestamp(isObject(sessionInfo.time) ? sessionInfo.time.created : undefined);
     return {
       events,
@@ -1980,9 +1971,6 @@ function parseOpenCodeDocument(transcript) {
     throw invalidOpenCodeTranscript();
   }
   return parsed;
-}
-function nonemptyString4(value) {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 function stringContent2(value) {
   if (typeof value === "string")

--- a/src/adapters/atif/index.ts
+++ b/src/adapters/atif/index.ts
@@ -9,6 +9,7 @@ import {
   blocksText,
   isObject,
   jsonString,
+  nonemptyString,
   parseTimestamp,
 } from "../shared.js";
 
@@ -23,9 +24,9 @@ export const atifAdapter: SourceAdapter = {
     const document = parseAtifDocument(transcript);
     const diagnostics: Diagnostic[] = [];
     const events: DecodedEvent[] = [];
-    const trajectoryId = atifNonemptyString(document.trajectory_id);
-    const sessionId = atifNonemptyString(document.session_id);
-    const rootModel = atifNonemptyString(document.agent.model_name);
+    const trajectoryId = nonemptyString(document.trajectory_id);
+    const sessionId = nonemptyString(document.session_id);
+    const rootModel = nonemptyString(document.agent.model_name);
     let createdAt: Date | undefined;
 
     for (let index = 0; index < document.steps.length; index += 1) {
@@ -48,7 +49,7 @@ export const atifAdapter: SourceAdapter = {
       createdAt ??= timestamp;
       const model =
         step.source === "agent"
-          ? atifNonemptyString(step.model_name) ?? rootModel
+          ? nonemptyString(step.model_name) ?? rootModel
           : undefined;
       const sourceRecordId = trajectoryId
         ? `trajectory:${trajectoryId}:step:${expectedStepId}`
@@ -104,8 +105,8 @@ export const atifAdapter: SourceAdapter = {
         }
         for (const rawCall of step.tool_calls ?? []) {
           if (!isObject(rawCall)) throw invalidAtifTranscript();
-          const callId = atifNonemptyString(rawCall.tool_call_id);
-          const name = atifNonemptyString(rawCall.function_name);
+          const callId = nonemptyString(rawCall.tool_call_id);
+          const name = nonemptyString(rawCall.function_name);
           emit({
             type: "tool_call",
             args: jsonString(rawCall.arguments),
@@ -122,7 +123,7 @@ export const atifAdapter: SourceAdapter = {
       }
       for (const rawResult of step.observation.results) {
         if (!isObject(rawResult)) throw invalidAtifTranscript();
-        const callId = atifNonemptyString(rawResult.source_call_id);
+        const callId = nonemptyString(rawResult.source_call_id);
         const content = observationContent(rawResult);
         emit(
           callId
@@ -196,10 +197,6 @@ function observationContent(result: Record<string, unknown>): string {
     return jsonString({ subagent_trajectory_ref: result.subagent_trajectory_ref });
   }
   return "";
-}
-
-function atifNonemptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function invalidAtifTranscript(): NormalizationError {

--- a/src/adapters/copilot-cli/index.ts
+++ b/src/adapters/copilot-cli/index.ts
@@ -8,6 +8,7 @@ import { NormalizationError } from "../../types.js";
 import {
   isObject,
   jsonString,
+  nonemptyString,
   parseJsonLines,
   parseTimestamp,
 } from "../shared.js";
@@ -191,10 +192,6 @@ export const copilotCliAdapter: SourceAdapter = {
     };
   },
 };
-
-function nonemptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
 
 function copilotResultContent(data: Record<string, unknown>): string {
   if (isObject(data.result)) {

--- a/src/adapters/gemini-cli/index.ts
+++ b/src/adapters/gemini-cli/index.ts
@@ -9,6 +9,7 @@ import {
   blocksText,
   isObject,
   jsonString,
+  nonemptyString,
   parseTimestamp,
 } from "../shared.js";
 
@@ -158,10 +159,6 @@ function parseGeminiDocument(transcript: string): GeminiDocument {
     throw invalidGeminiTranscript();
   }
   return parsed as GeminiDocument;
-}
-
-function nonemptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function thoughtContent(value: unknown): string {

--- a/src/adapters/letta-code/index.ts
+++ b/src/adapters/letta-code/index.ts
@@ -5,7 +5,11 @@ import type {
 } from "../../internal.js";
 import type { Diagnostic } from "../../types.js";
 import { NormalizationError } from "../../types.js";
-import { parseJsonLines, parseTimestamp } from "../shared.js";
+import {
+  nonemptyString,
+  parseJsonLines,
+  parseTimestamp,
+} from "../shared.js";
 
 const SUPPORTED_KINDS = new Set([
   "user",
@@ -156,10 +160,6 @@ export const lettaCodeAdapter: SourceAdapter = {
     };
   },
 };
-
-function nonemptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-}
 
 function invalidLettaCodeTranscript(): NormalizationError {
   return new NormalizationError(

--- a/src/adapters/opencode/index.ts
+++ b/src/adapters/opencode/index.ts
@@ -8,6 +8,7 @@ import { NormalizationError } from "../../types.js";
 import {
   isObject,
   jsonString,
+  nonemptyString,
   parseTimestamp,
 } from "../shared.js";
 
@@ -203,10 +204,6 @@ function parseOpenCodeDocument(transcript: string): OpenCodeDocument {
     throw invalidOpenCodeTranscript();
   }
   return parsed as OpenCodeDocument;
-}
-
-function nonemptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 function stringContent(value: unknown): string {

--- a/src/adapters/shared.ts
+++ b/src/adapters/shared.ts
@@ -56,6 +56,10 @@ export function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+export function nonemptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
 export function parseTimestamp(value: unknown): Date | undefined {
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value;
   if (typeof value === "number" && value > 1e11) {


### PR DESCRIPTION
## Summary
- move the identical `nonemptyString` helper into `src/adapters/shared.ts`
- reuse it from ATIF, Copilot CLI, Gemini CLI, Letta Code, and OpenCode
- refresh the vendored Python runtime bundle

No normalization behavior changes.

## Validation
- `bun run check` (178 passed, 7 dependency-gated skips)
- focused normalization and canonical suites (153 passed)
- `git diff --check`