### PR TITLE
fix(droid): preserve native message timestamps

### DIFF
--- a/src/adapters/droid/README.md
+++ b/src/adapters/droid/README.md
@@ -11,8 +11,12 @@ blocks (with JSON-stringified inputs), and user `tool_result` blocks linked by
 `tool_use_id`. Droid has no per-event timestamps or transcript model field, so
 the shared core synthesizes timestamps and no model is added to metadata.
 
-`todo_state`, `session_end`, and `compaction_state` rows are transport noise
-and are dropped.
+Current Droid `message` rows include a top-level timestamp. The adapter carries
+that timestamp to every canonical component emitted from the row. Older exports
+without timestamps remain supported and use the shared synthesized-time policy.
+
+`todo_state`, `session_end`, and `compaction_state` rows are transport noise and
+are dropped.
 
 ## Listing
 

--- a/src/adapters/droid/index.ts
+++ b/src/adapters/droid/index.ts
@@ -4,7 +4,7 @@ import type {
   SourceAdapter,
 } from "../../internal.js";
 import type { Diagnostic } from "../../types.js";
-import { blocksText, isObject, jsonString, parseJsonLines } from "../shared.js";
+import { blocksText, isObject, jsonString, parseJsonLines, parseTimestamp } from "../shared.js";
 
 const TRANSPORT_TYPES = new Set([
   "todo_state",
@@ -21,6 +21,7 @@ export const droidAdapter: SourceAdapter = {
     const events: DecodedEvent[] = [];
     let cwd: string | undefined;
     let sourceGroupId: string | undefined;
+    let createdAt: Date | undefined;
 
     for (const { value: record, line, byteOffset } of parseJsonLines(
       transcript,
@@ -42,6 +43,8 @@ export const droidAdapter: SourceAdapter = {
         continue;
       }
       if (recordType !== "message" || !isObject(record.message)) continue;
+      const timestamp = parseTimestamp(record.timestamp);
+      createdAt ??= timestamp;
 
       const role = record.message.role;
       if (role !== "user" && role !== "assistant") continue;
@@ -55,6 +58,7 @@ export const droidAdapter: SourceAdapter = {
           sourceOffset: byteOffset,
           sourceAnchorKind: "byte",
           componentIndex: componentIndex++,
+          ...(timestamp ? { timestamp } : {}),
         });
       };
 
@@ -102,6 +106,7 @@ export const droidAdapter: SourceAdapter = {
         source: "droid",
         ...(cwd ? { cwd } : {}),
         ...(sourceGroupId ? { sourceGroupId } : {}),
+        ...(createdAt ? { createdAt } : {}),
       },
       diagnostics,
     };

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -311,6 +311,31 @@ describe("public API", () => {
     );
   });
 
+  test("preserves native Droid message timestamps", () => {
+    const transcript = [
+      JSON.stringify({ type: "session_start", id: "droid-session", cwd: "/tmp/droid" }),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-08-22T00:01:21.608Z",
+        message: { role: "user", content: [{ type: "text", text: "Hello" }] },
+      }),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-08-22T00:01:22.309Z",
+        message: { role: "assistant", content: [{ type: "text", text: "Hi" }] },
+      }),
+    ].join("\n");
+
+    const result = normalizeTranscript({ source: "droid", transcript });
+    expect(result.records).toEqual(expect.arrayContaining([
+      expect.objectContaining({ role: "user", timestamp: "2026-08-22T00:01:21.608Z" }),
+      expect.objectContaining({ role: "assistant", timestamp: "2026-08-22T00:01:22.309Z" }),
+    ]));
+    expect(result.diagnostics).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "timestamps_synthesized" }),
+    ]));
+  });
+
   test("always returns diagnostics", () => {
     const result = normalizeTranscript({
       source: "codex",


### PR DESCRIPTION
Overlord (agent-c2adbf5c-8419-4211-8cd8-3740db164974)

## Problem

Droid stores a top-level ISO timestamp on each native `message` row. The adapter discarded it. Canonical normalization then synthesized timestamps from January 1, 2026, which the Dreams UI displayed as December 31 in Pacific Time.

## Change

Carry each native Droid message timestamp to every canonical component emitted from that row. Use the first message time as session creation time. Older timestamp-free exports still use the shared synthesis policy.

## Validation

- `npm test`: 179 passed, 7 skipped
- Added a regression test for exact Droid timestamp preservation.
- Confirmed the reported upload had 18 timestamped native rows but 58 synthesized canonical timestamps between Jan 1 00:00 and 00:14 UTC.

## Scope

This fixes future normalization. Existing uploads need re-normalization or re-upload after the fixed trajectory version reaches Dreams.