### PR TITLE
Add Amp thread export adapter

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -49,6 +49,36 @@ default bounds. Intentional target-schema differences are documented beside
 the adapter: embedded subagent timelines, metrics, and custom metadata have no
 equivalent in trajectory-v1.
 
+## Amp whole-thread export
+
+The Amp adapter was checked on 2026-08-22 against two actual whole-thread JSON
+documents emitted by `amp threads export` from installed Amp
+`0.0.1787378726-g9570e9`. Both threads used the thread-actor representation and
+reported the sandbox executor used by Amp orbs. The audit inspected aggregate
+keys, types, statuses, and counts only; no real transcript prose, reasoning,
+tool payload, path, repository, account, device, or thread identifier was
+printed or retained in this repository.
+
+The complete orb export had 126 messages (63 user, 62 assistant, one info), 134
+uniquely linked complete tool calls/results, and a final complete assistant
+turn. It normalized to 421 canonical records: one meta, two user, 138
+reasoning, 12 assistant prose, 134 assistant tool-call, and 134 tool-result
+records. All 420 body records used native protocol-message identity and were
+ordered by the source message array plus numeric component index. Diagnostics
+were one dropped compaction info record, 78 default-bound tool-result
+truncations, and 134 timestamp interpolations for result messages whose native
+export had no timestamp. No incompleteness, orphan, duplicate, or synthesized
+identity diagnostic occurred.
+
+The actively written orb export normalized to 36 records with exactly one
+`incomplete_transcript` diagnostic for its unmatched final user turn. This
+preserves the observable prefix without inventing the session-end event that
+Amp does not expose. Sanitized fixtures cover the sandbox/orb envelope,
+reasoning, structured linked tools, source-native status, sparse timestamps,
+compaction info, multiple repository trees, incomplete blocks, duplicate
+terminal results, malformed/truncated JSON, duplicate identity, unsupported
+semantic blocks, non-terminal results, and unmatched tails.
+
 ## Production TypeScript reference
 
 Reference: `letta-agent-sdk` `dream-pipeline` commit `3d3e3e0`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ and is empty when the transcript required no recoverable cleanup.
 | `source` | Accepted input format | Normalized `meta.source` |
 | --- | --- | --- |
 | [`atif`](src/adapters/atif/) | ATIF-v1.0 through ATIF-v1.7 whole-trajectory JSON | `atif` |
+| [`amp`](src/adapters/amp/) | Whole-thread JSON from `amp threads export <thread>` | `amp` |
 | [`claude-code`](src/adapters/claude-code/) | Native Claude Code JSONL | `claude-code` |
 | [`codex`](src/adapters/codex/) | Native Codex rollout JSONL | `codex` |
 | [`copilot-cli`](src/adapters/copilot-cli/) | Native GitHub Copilot CLI event JSONL | `copilot-cli` |
@@ -112,7 +113,7 @@ what the adapter drops.
 `listTrajectories()` enumerates the sessions in a source's standard local
 store, newest first, with cursor pagination. It is a discovery layer beside
 normalization — `normalizeTranscript()` itself never touches the filesystem.
-ATIF, Copilot CLI, Cursor, Gemini CLI, and OpenCode are export-only input
+Amp, ATIF, Copilot CLI, Cursor, Gemini CLI, and OpenCode are export-only input
 contracts and intentionally return `listing_unavailable`; callers locate and
 read the exports themselves.
 

--- a/fixtures/amp/cleanup/expected.json
+++ b/fixtures/amp/cleanup/expected.json
@@ -1,0 +1,60 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "amp",
+      "cwd": "/workspace/cleanup"
+    },
+    {
+      "role": "user",
+      "content": "Run the check.",
+      "timestamp": "2026-08-22T11:00:00.000Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "cleanup-tool",
+          "name": "check",
+          "args": "{\"target\":\"workspace\"}"
+        }
+      ],
+      "timestamp": "2026-08-22T11:00:01.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "cleanup-tool",
+      "content": "check failed",
+      "ok": false,
+      "timestamp": "2026-08-22T11:00:02.500Z"
+    },
+    {
+      "role": "assistant",
+      "content": "The check failed.",
+      "timestamp": "2026-08-22T11:00:04.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "incomplete_transcript",
+      "message": "Amp assistant block 1:1 is not complete.",
+      "count": 1
+    },
+    {
+      "code": "noise_record_dropped",
+      "message": "Dropped an Amp info record at message 3.",
+      "count": 1
+    },
+    {
+      "code": "duplicate_tool_result",
+      "message": "Dropped a duplicate result for tool call \"cleanup-tool\".",
+      "recordIndex": 4
+    },
+    {
+      "code": "timestamps_interpolated",
+      "message": "Interpolated timestamps for 2 normalized records.",
+      "count": 2
+    }
+  ]
+}

--- a/fixtures/amp/cleanup/input.json
+++ b/fixtures/amp/cleanup/input.json
@@ -61,7 +61,12 @@
       "role": "info",
       "messageId": 3,
       "protocolMessageID": "cleanup-info-1",
-      "content": [{ "type": "summary", "summary": "Compaction summary." }]
+      "content": [
+        {
+          "type": "summary",
+          "summary": { "type": "message", "summary": "Compaction summary." }
+        }
+      ]
     },
     {
       "role": "assistant",

--- a/fixtures/amp/cleanup/input.json
+++ b/fixtures/amp/cleanup/input.json
@@ -1,0 +1,81 @@
+{
+  "id": "T-sanitized-cleanup",
+  "created": 1787396400000,
+  "env": {
+    "initial": {
+      "workingDirectory": "/workspace/cleanup",
+      "trees": [
+        { "repository": { "ref": "main" } },
+        { "repository": { "ref": "docs" } }
+      ]
+    }
+  },
+  "meta": { "executorType": "sandbox" },
+  "messages": [
+    {
+      "role": "user",
+      "messageId": 0,
+      "protocolMessageID": "cleanup-user-1",
+      "content": [{ "type": "text", "text": "Run the check." }]
+    },
+    {
+      "role": "assistant",
+      "messageId": 1,
+      "protocolMessageID": "cleanup-assistant-1",
+      "state": { "type": "complete", "stopReason": "tool_use" },
+      "usage": { "timestamp": "2026-08-22T11:00:01.000Z" },
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "cleanup-tool",
+          "name": "check",
+          "input": { "target": "workspace" },
+          "complete": true,
+          "blockState": "complete"
+        },
+        {
+          "type": "text",
+          "text": "unfinished text",
+          "blockState": "pending"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "messageId": 2,
+      "protocolMessageID": "cleanup-user-2",
+      "content": [
+        {
+          "type": "tool_result",
+          "toolUseID": "cleanup-tool",
+          "run": { "status": "error", "result": "check failed" }
+        },
+        {
+          "type": "tool_result",
+          "toolUseID": "cleanup-tool",
+          "run": { "status": "error", "result": "duplicate terminal" }
+        }
+      ]
+    },
+    {
+      "role": "info",
+      "messageId": 3,
+      "protocolMessageID": "cleanup-info-1",
+      "content": [{ "type": "summary", "summary": "Compaction summary." }]
+    },
+    {
+      "role": "assistant",
+      "messageId": 4,
+      "protocolMessageID": "cleanup-assistant-2",
+      "state": { "type": "complete", "stopReason": "end_turn" },
+      "usage": { "timestamp": "2026-08-22T11:00:04.000Z" },
+      "content": [
+        {
+          "type": "text",
+          "text": "The check failed.",
+          "blockState": "complete"
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/amp/orb-thread-export/expected.json
+++ b/fixtures/amp/orb-thread-export/expected.json
@@ -1,0 +1,57 @@
+{
+  "records": [
+    {
+      "role": "meta",
+      "source": "amp",
+      "cwd": "/workspace/example",
+      "git_branch": "main",
+      "model": "example/model"
+    },
+    {
+      "role": "user",
+      "content": "Inspect the workspace.",
+      "timestamp": "2026-08-22T10:00:00.000Z"
+    },
+    {
+      "role": "reasoning",
+      "content": "I will inspect it.",
+      "timestamp": "2026-08-22T10:00:00.500Z"
+    },
+    {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "tool-1",
+          "name": "shell_command",
+          "args": "{\"command\":\"pwd\"}"
+        }
+      ],
+      "timestamp": "2026-08-22T10:00:01.000Z"
+    },
+    {
+      "role": "tool",
+      "tool_call_id": "tool-1",
+      "content": "{\"output\":\"/workspace/example\",\"exitCode\":0}",
+      "ok": true,
+      "timestamp": "2026-08-22T10:00:02.500Z"
+    },
+    {
+      "role": "assistant",
+      "content": "The workspace is ready.",
+      "timestamp": "2026-08-22T10:00:04.000Z"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "noise_record_dropped",
+      "message": "Dropped an Amp info record at message 3.",
+      "count": 1
+    },
+    {
+      "code": "timestamps_interpolated",
+      "message": "Interpolated timestamps for 1 normalized records.",
+      "count": 1
+    }
+  ]
+}

--- a/fixtures/amp/orb-thread-export/input.json
+++ b/fixtures/amp/orb-thread-export/input.json
@@ -86,7 +86,12 @@
       "messageId": 3,
       "protocolMessageID": "msg-info-1",
       "protocolMessageVersion": 0,
-      "content": [{ "type": "summary", "summary": "Compaction summary." }]
+      "content": [
+        {
+          "type": "summary",
+          "summary": { "type": "message", "summary": "Compaction summary." }
+        }
+      ]
     },
     {
       "role": "assistant",

--- a/fixtures/amp/orb-thread-export/input.json
+++ b/fixtures/amp/orb-thread-export/input.json
@@ -1,0 +1,112 @@
+{
+  "v": 8,
+  "id": "T-sanitized-orb-thread",
+  "created": 1787392800000,
+  "updatedAt": "2026-08-22T10:00:05.000Z",
+  "env": {
+    "initial": {
+      "workingDirectory": "/workspace/example",
+      "platform": {
+        "client": "CLI Execute Mode",
+        "clientType": "cli",
+        "webBrowser": false
+      },
+      "trees": [
+        {
+          "displayName": "example",
+          "repository": {
+            "type": "git",
+            "ref": "main"
+          },
+          "uri": "file:///workspace/example"
+        }
+      ]
+    }
+  },
+  "meta": {
+    "executorType": "sandbox",
+    "createdOnServer": false,
+    "usesThreadActors": true
+  },
+  "messages": [
+    {
+      "role": "user",
+      "messageId": 0,
+      "protocolMessageID": "msg-user-1",
+      "protocolMessageVersion": 0,
+      "meta": { "sentAt": 1787392800000 },
+      "content": [{ "type": "text", "text": "Inspect the workspace." }]
+    },
+    {
+      "role": "assistant",
+      "messageId": 1,
+      "protocolMessageID": "msg-assistant-1",
+      "protocolMessageVersion": 0,
+      "state": { "type": "complete", "stopReason": "tool_use" },
+      "usage": {
+        "model": "example/model",
+        "timestamp": "2026-08-22T10:00:01.000Z"
+      },
+      "content": [
+        {
+          "type": "thinking",
+          "thinking": "I will inspect it.",
+          "blockState": "complete",
+          "startTime": 1787392800500,
+          "finalTime": 1787392800750
+        },
+        {
+          "type": "tool_use",
+          "id": "tool-1",
+          "name": "shell_command",
+          "input": { "command": "pwd" },
+          "complete": true,
+          "blockState": "complete"
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "messageId": 2,
+      "protocolMessageID": "msg-user-2",
+      "protocolMessageVersion": 0,
+      "content": [
+        {
+          "type": "tool_result",
+          "toolUseID": "tool-1",
+          "run": {
+            "status": "done",
+            "result": { "output": "/workspace/example", "exitCode": 0 }
+          }
+        }
+      ]
+    },
+    {
+      "role": "info",
+      "messageId": 3,
+      "protocolMessageID": "msg-info-1",
+      "protocolMessageVersion": 0,
+      "content": [{ "type": "summary", "summary": "Compaction summary." }]
+    },
+    {
+      "role": "assistant",
+      "messageId": 4,
+      "protocolMessageID": "msg-assistant-2",
+      "protocolMessageVersion": 0,
+      "state": { "type": "complete", "stopReason": "end_turn" },
+      "usage": {
+        "model": "example/model",
+        "timestamp": "2026-08-22T10:00:05.000Z"
+      },
+      "content": [
+        {
+          "type": "text",
+          "text": "The workspace is ready.",
+          "blockState": "complete",
+          "startTime": 1787392804000,
+          "finalTime": 1787392805000
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/canonical/amp__orb-thread-export.json
+++ b/fixtures/canonical/amp__orb-thread-export.json
@@ -1,0 +1,159 @@
+{
+  "records": [
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "meta",
+      "source_identity_kind": "synthetic",
+      "source_order_id": "0|0000-00-00T00:00:00.000Z|00000000000000000000|meta",
+      "component_index": 0,
+      "record_type": "meta",
+      "record_id": "29ce685cb554bc47023f558418db7958b960df8d8bb500e5805f964008f46f26",
+      "record_hash": "380fbed96fe806a1096a633a113366b4ce2833b7bd2e127545d7e5d3d89d9169",
+      "content_hash": "2d6f6665b10c17fe43afb2596fb3c2e05257cdda357e629dedb3eff8e6eda8ed",
+      "source_timestamp": null,
+      "record_timestamp": null,
+      "content": null,
+      "tool_call_id": null,
+      "tool_name": null,
+      "tool_arguments_json": null,
+      "tool_result_json": null,
+      "tool_result_ok": null,
+      "record_json": "{\"cwd\":\"/workspace/example\",\"git_branch\":\"main\",\"model\":\"example/model\",\"role\":\"meta\",\"source\":\"amp\"}"
+    },
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "msg-user-1",
+      "source_identity_kind": "native",
+      "source_order_id": "1|0000-00-00T00:00:00.001Z|00000000000000000000|msg-user-1",
+      "component_index": 0,
+      "record_type": "user",
+      "record_id": "ce92e6104d53ebcdc729a935b934fc3e8aa79f356e21f937dd5ca4ca14a3d1b7",
+      "record_hash": "370f50b97d85f7bebded4f36a2ec390e8b693a38ad4e96472324564f979c26e8",
+      "content_hash": "3d24dab2ff33b90ff87d680cb66a61f35f97d5167d000de67634c989914e3511",
+      "source_timestamp": "2026-08-22T10:00:00.000Z",
+      "record_timestamp": "2026-08-22T10:00:00.000Z",
+      "content": "Inspect the workspace.",
+      "tool_call_id": null,
+      "tool_name": null,
+      "tool_arguments_json": null,
+      "tool_result_json": null,
+      "tool_result_ok": null,
+      "record_json": "{\"content\":\"Inspect the workspace.\",\"role\":\"user\",\"timestamp\":\"2026-08-22T10:00:00.000Z\"}"
+    },
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "msg-assistant-1",
+      "source_identity_kind": "native",
+      "source_order_id": "1|0000-00-00T00:00:00.001Z|00000000000000000001|msg-assistant-1",
+      "component_index": 0,
+      "record_type": "reasoning",
+      "record_id": "ab0da11e396415974a29bb20a394686b5f303c7bf87fb69e6b115c2049544102",
+      "record_hash": "51c90c719f2e7e6d44684f53c5cbf8aafd837d4dcda7676e9e487be217f42797",
+      "content_hash": "66a8cf5fb4c8da2c585ead073514de8ce75d05c6f99f1e32a202d3cd982fcb2e",
+      "source_timestamp": "2026-08-22T10:00:00.500Z",
+      "record_timestamp": "2026-08-22T10:00:00.500Z",
+      "content": "I will inspect it.",
+      "tool_call_id": null,
+      "tool_name": null,
+      "tool_arguments_json": null,
+      "tool_result_json": null,
+      "tool_result_ok": null,
+      "record_json": "{\"content\":\"I will inspect it.\",\"role\":\"reasoning\",\"timestamp\":\"2026-08-22T10:00:00.500Z\"}"
+    },
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "msg-assistant-1",
+      "source_identity_kind": "native",
+      "source_order_id": "1|0000-00-00T00:00:00.001Z|00000000000000000001|msg-assistant-1",
+      "component_index": 1,
+      "record_type": "assistant-tool-call",
+      "record_id": "b326ed4fc418db256d93957bf33aaf3c08419851b5c3b36254bb99036f43bba2",
+      "record_hash": "a5f75636e9a9b0a3bcaab62fe1da6c880b6a503d51a9b5b12022b6e02f485e80",
+      "content_hash": "37ff959d7491a75a6c1c3495eaf98ee89e9ed38bb906c86b5fff6749af776130",
+      "source_timestamp": "2026-08-22T10:00:01.000Z",
+      "record_timestamp": "2026-08-22T10:00:01.000Z",
+      "content": null,
+      "tool_call_id": "tool-1",
+      "tool_name": "shell_command",
+      "tool_arguments_json": "{\"command\":\"pwd\"}",
+      "tool_result_json": null,
+      "tool_result_ok": null,
+      "record_json": "{\"content\":null,\"role\":\"assistant\",\"timestamp\":\"2026-08-22T10:00:01.000Z\",\"tool_calls\":[{\"args\":\"{\\\"command\\\":\\\"pwd\\\"}\",\"id\":\"tool-1\",\"name\":\"shell_command\"}]}"
+    },
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "msg-user-2",
+      "source_identity_kind": "native",
+      "source_order_id": "1|0000-00-00T00:00:00.001Z|00000000000000000002|msg-user-2",
+      "component_index": 0,
+      "record_type": "tool",
+      "record_id": "3a7ae30e134ae20f0e722f05df15a07e364d8d02a8f6390f17828ac02ddcbc9a",
+      "record_hash": "5cd717cbd175f4cbeaa6936f542aeb23769057b74c01c006fbf5a86094b49fb7",
+      "content_hash": "d38b5ef4ecc5befce180bdf9d8294a3e4e3dc0213c757f710d58706334a9d1ff",
+      "source_timestamp": null,
+      "record_timestamp": "2026-08-22T10:00:02.500Z",
+      "content": null,
+      "tool_call_id": "tool-1",
+      "tool_name": null,
+      "tool_arguments_json": null,
+      "tool_result_json": "{\"output\":\"/workspace/example\",\"exitCode\":0}",
+      "tool_result_ok": true,
+      "record_json": "{\"content\":\"{\\\"output\\\":\\\"/workspace/example\\\",\\\"exitCode\\\":0}\",\"ok\":true,\"role\":\"tool\",\"timestamp\":\"2026-08-22T10:00:02.500Z\",\"tool_call_id\":\"tool-1\"}"
+    },
+    {
+      "source_type": "amp",
+      "source_group_id": "T-sanitized-orb-thread",
+      "stable_source_record_id": "msg-assistant-2",
+      "source_identity_kind": "native",
+      "source_order_id": "1|0000-00-00T00:00:00.001Z|00000000000000000004|msg-assistant-2",
+      "component_index": 0,
+      "record_type": "assistant",
+      "record_id": "68be0565adc72d0aa2a35bd8da81aaacd4328bf7113a7f1f3113165feae68e60",
+      "record_hash": "bce0300676d5668598feaf41d1d851fcf1184dc4018d572ad83bd1f7e625cf64",
+      "content_hash": "d6898b005a044af67809fae95186fe40d8f5d7798bd20b28dfcb389d51fbfd41",
+      "source_timestamp": "2026-08-22T10:00:04.000Z",
+      "record_timestamp": "2026-08-22T10:00:04.000Z",
+      "content": "The workspace is ready.",
+      "tool_call_id": null,
+      "tool_name": null,
+      "tool_arguments_json": null,
+      "tool_result_json": null,
+      "tool_result_ok": null,
+      "record_json": "{\"content\":\"The workspace is ready.\",\"role\":\"assistant\",\"timestamp\":\"2026-08-22T10:00:04.000Z\"}"
+    }
+  ],
+  "diagnostics": [
+    {
+      "code": "noise_record_dropped",
+      "message": "Dropped an Amp info record at message 3.",
+      "count": 1
+    },
+    {
+      "code": "timestamps_interpolated",
+      "message": "Interpolated timestamps for 1 normalized records.",
+      "count": 1
+    }
+  ],
+  "normalizer_version": "0.3.0",
+  "canonical_schema_version": 3,
+  "config": {
+    "bounds": {
+      "toolArguments": {
+        "maxCharacters": 20000
+      },
+      "toolResults": {
+        "maxCharacters": 2500,
+        "strategy": "head-tail"
+      }
+    },
+    "filters": {
+      "toolResults": "include",
+      "systemMessages": "omit"
+    }
+  }
+}

--- a/python/src/trajectory/_types.py
+++ b/python/src/trajectory/_types.py
@@ -3,11 +3,11 @@
 from typing import Literal, TypedDict, Union
 
 TrajectorySource = Literal[
-    "atif", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
+    "atif", "amp", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi"
 ]
 CheckpointTrajectorySource = Literal["deepagents"]
 AnyTrajectorySource = Literal[
-    "atif", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
+    "atif", "amp", "claude-code", "codex", "copilot-cli", "cursor", "droid", "gemini-cli", "hermes", "letta-code", "omp", "openclaw", "opencode", "openhands", "pi", "deepagents"
 ]
 ToolResultTruncationStrategy = Literal["head", "head-tail"]
 ToolResultPolicy = Literal["include", "omit"]
@@ -15,6 +15,7 @@ SystemMessagePolicy = Literal["include", "omit"]
 DiagnosticCode = Literal[
     "invalid_json_line",
     "non_object_json_line",
+    "incomplete_transcript",
     "injected_context_dropped",
     "noise_record_dropped",
     "sidechain_record_dropped",

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -252,6 +252,7 @@ function invalidAtifTranscript() {
 
 // src/adapters/amp/index.ts
 var TERMINAL_TOOL_STATUSES = new Set(["done", "error", "cancelled"]);
+var NONTERMINAL_TOOL_STATUSES = new Set(["running", "pending"]);
 var ampAdapter = {
   source: "amp",
   decode(transcript) {
@@ -266,9 +267,9 @@ var ampAdapter = {
     const events = [];
     const messageIds = new Set;
     const protocolMessageIds = new Set;
-    const toolCallIds = new Set;
-    const terminalResultIds = new Set;
-    const nonterminalResultIds = new Set;
+    const toolCallCounts = new Map;
+    const terminalResultCounts = new Map;
+    const nonterminalResultCounts = new Map;
     let lastConversationalRole;
     for (let messageIndex = 0;messageIndex < root.messages.length; messageIndex += 1) {
       const message = root.messages[messageIndex];
@@ -294,6 +295,12 @@ var ampAdapter = {
         invalid(`Amp message ${messageIndex} must contain a content array.`);
       }
       if (message.role === "info") {
+        for (let componentIndex = 0;componentIndex < message.content.length; componentIndex += 1) {
+          const block = message.content[componentIndex];
+          if (!isObject(block) || block.type !== "summary" || !isObject(block.summary) || block.summary.type !== "message" || typeof block.summary.summary !== "string") {
+            invalid(`Amp info block ${messageIndex}:${componentIndex} has an unsupported shape.`);
+          }
+        }
         diagnostics.push({
           code: "noise_record_dropped",
           message: `Dropped an Amp info record at message ${messageIndex}.`,
@@ -334,8 +341,8 @@ var ampAdapter = {
           if (!callId || !isObject(block.run) || typeof block.run.status !== "string") {
             invalid(`Amp tool result ${messageIndex}:${componentIndex} is malformed.`);
           }
-          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
-            nonterminalResultIds.add(callId);
+          if (NONTERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            increment(nonterminalResultCounts, callId);
             diagnostics.push({
               code: "incomplete_transcript",
               message: `Amp tool result at message ${messageIndex} is not terminal.`,
@@ -343,7 +350,13 @@ var ampAdapter = {
             });
             continue;
           }
-          terminalResultIds.add(callId);
+          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            invalid(`Amp tool result ${messageIndex}:${componentIndex} has an unsupported status.`);
+          }
+          if (!Object.hasOwn(block.run, "result")) {
+            invalid(`Amp terminal tool result ${messageIndex}:${componentIndex} must contain result.`);
+          }
+          increment(terminalResultCounts, callId);
           events.push({
             type: "tool_result",
             callId,
@@ -408,23 +421,27 @@ var ampAdapter = {
             invalid(`Amp tool use ${messageIndex}:${componentIndex} must contain an id.`);
           }
           const name = nonemptyString(block.name);
-          toolCallIds.add(callId);
+          if (!name || !isObject(block.input)) {
+            invalid(`Amp tool use ${messageIndex}:${componentIndex} is malformed.`);
+          }
+          increment(toolCallCounts, callId);
           events.push({
             type: "tool_call",
             id: callId,
-            ...name ? { name } : {},
+            name,
             args: jsonString(block.input),
             ...shared
           });
         }
       }
     }
-    for (const callId of toolCallIds) {
-      if (!terminalResultIds.has(callId) && !nonterminalResultIds.has(callId)) {
+    for (const [callId, callCount] of toolCallCounts) {
+      const resultCount = (terminalResultCounts.get(callId) ?? 0) + (nonterminalResultCounts.get(callId) ?? 0);
+      if (callCount > resultCount) {
         diagnostics.push({
           code: "incomplete_transcript",
           message: "Amp thread export contains a tool call without a result.",
-          count: 1
+          count: callCount - resultCount
         });
       }
     }
@@ -465,7 +482,15 @@ function parseExport(transcript) {
   return parsed;
 }
 function resultText(result) {
-  return typeof result === "string" ? result : jsonString(result);
+  if (typeof result === "string")
+    return result;
+  const serialized = JSON.stringify(result);
+  if (serialized === undefined)
+    invalid("Amp terminal tool result is not JSON-serializable.");
+  return serialized;
+}
+function increment(counts, id) {
+  counts.set(id, (counts.get(id) ?? 0) + 1);
 }
 function singleTreeRef(value) {
   if (!Array.isArray(value) || value.length !== 1 || !isObject(value[0]))

--- a/python/src/trajectory/_vendor/trajectory-cli.mjs
+++ b/python/src/trajectory/_vendor/trajectory-cli.mjs
@@ -250,6 +250,233 @@ function invalidAtifTranscript() {
   return new NormalizationError("invalid_input", "ATIF transcript must be one ATIF-v1.0 through ATIF-v1.7 JSON trajectory object with agent metadata and sequential steps.");
 }
 
+// src/adapters/amp/index.ts
+var TERMINAL_TOOL_STATUSES = new Set(["done", "error", "cancelled"]);
+var ampAdapter = {
+  source: "amp",
+  decode(transcript) {
+    const root = parseExport(transcript);
+    const sourceGroupId = nonemptyString(root.id);
+    if (!sourceGroupId)
+      invalid("Amp thread export must contain a non-empty root id.");
+    if (!Array.isArray(root.messages)) {
+      invalid("Amp thread export must contain a messages array.");
+    }
+    const diagnostics = [];
+    const events = [];
+    const messageIds = new Set;
+    const protocolMessageIds = new Set;
+    const toolCallIds = new Set;
+    const terminalResultIds = new Set;
+    const nonterminalResultIds = new Set;
+    let lastConversationalRole;
+    for (let messageIndex = 0;messageIndex < root.messages.length; messageIndex += 1) {
+      const message = root.messages[messageIndex];
+      if (!isObject(message))
+        invalid(`Amp message ${messageIndex} must be an object.`);
+      const messageId = message.messageId;
+      if (!Number.isSafeInteger(messageId) || messageId < 0) {
+        invalid(`Amp message ${messageIndex} must have a non-negative integer messageId.`);
+      }
+      if (messageIds.has(messageId)) {
+        invalid(`Amp thread export contains duplicate messageId at message ${messageIndex}.`);
+      }
+      messageIds.add(messageId);
+      const sourceRecordId = nonemptyString(message.protocolMessageID);
+      if (!sourceRecordId) {
+        invalid(`Amp message ${messageIndex} must have a non-empty protocolMessageID.`);
+      }
+      if (protocolMessageIds.has(sourceRecordId)) {
+        invalid(`Amp thread export contains duplicate protocolMessageID at message ${messageIndex}.`);
+      }
+      protocolMessageIds.add(sourceRecordId);
+      if (!Array.isArray(message.content)) {
+        invalid(`Amp message ${messageIndex} must contain a content array.`);
+      }
+      if (message.role === "info") {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message: `Dropped an Amp info record at message ${messageIndex}.`,
+          count: 1
+        });
+        continue;
+      }
+      if (message.role !== "user" && message.role !== "assistant") {
+        invalid(`Amp message ${messageIndex} has an unsupported semantic role.`);
+      }
+      lastConversationalRole = message.role;
+      if (message.role === "user") {
+        const timestamp = parseTimestamp(isObject(message.meta) ? message.meta.sentAt : undefined);
+        for (let componentIndex = 0;componentIndex < message.content.length; componentIndex += 1) {
+          const block = message.content[componentIndex];
+          if (!isObject(block)) {
+            invalid(`Amp user block ${messageIndex}:${componentIndex} must be an object.`);
+          }
+          if (block.type === "text") {
+            if (typeof block.text !== "string") {
+              invalid(`Amp text block ${messageIndex}:${componentIndex} must contain text.`);
+            }
+            events.push({
+              type: "message",
+              role: "user",
+              content: block.text,
+              ...timestamp ? { timestamp } : {},
+              sourceRecordId,
+              sourceSequence: messageIndex,
+              componentIndex
+            });
+            continue;
+          }
+          if (block.type !== "tool_result") {
+            invalid(`Amp user block ${messageIndex}:${componentIndex} has an unsupported type.`);
+          }
+          const callId = nonemptyString(block.toolUseID);
+          if (!callId || !isObject(block.run) || typeof block.run.status !== "string") {
+            invalid(`Amp tool result ${messageIndex}:${componentIndex} is malformed.`);
+          }
+          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            nonterminalResultIds.add(callId);
+            diagnostics.push({
+              code: "incomplete_transcript",
+              message: `Amp tool result at message ${messageIndex} is not terminal.`,
+              count: 1
+            });
+            continue;
+          }
+          terminalResultIds.add(callId);
+          events.push({
+            type: "tool_result",
+            callId,
+            content: resultText(block.run.result),
+            ok: block.run.status === "done",
+            ...timestamp ? { timestamp } : {},
+            sourceRecordId,
+            sourceSequence: messageIndex,
+            componentIndex
+          });
+        }
+        continue;
+      }
+      const messageComplete = isObject(message.state) && message.state.type === "complete";
+      if (!messageComplete) {
+        diagnostics.push({
+          code: "incomplete_transcript",
+          message: `Amp assistant turn at message ${messageIndex} is not complete.`,
+          count: 1
+        });
+      }
+      const fallbackTimestamp = parseTimestamp(isObject(message.usage) ? message.usage.timestamp : undefined);
+      const model = nonemptyString(isObject(message.usage) ? message.usage.model : undefined);
+      for (let componentIndex = 0;componentIndex < message.content.length; componentIndex += 1) {
+        const block = message.content[componentIndex];
+        if (!isObject(block)) {
+          invalid(`Amp assistant block ${messageIndex}:${componentIndex} must be an object.`);
+        }
+        if (block.type !== "text" && block.type !== "thinking" && block.type !== "tool_use") {
+          invalid(`Amp assistant block ${messageIndex}:${componentIndex} has an unsupported type.`);
+        }
+        const blockComplete = block.blockState === "complete" && (block.type !== "tool_use" || block.complete === true);
+        if (!blockComplete) {
+          diagnostics.push({
+            code: "incomplete_transcript",
+            message: `Amp assistant block ${messageIndex}:${componentIndex} is not complete.`,
+            count: 1
+          });
+          continue;
+        }
+        const timestamp = parseTimestamp(block.startTime) ?? parseTimestamp(block.finalTime) ?? fallbackTimestamp;
+        const shared = {
+          ...timestamp ? { timestamp } : {},
+          ...model ? { model } : {},
+          sourceRecordId,
+          sourceSequence: messageIndex,
+          componentIndex
+        };
+        if (block.type === "text") {
+          if (typeof block.text !== "string") {
+            invalid(`Amp text block ${messageIndex}:${componentIndex} must contain text.`);
+          }
+          events.push({ type: "message", role: "assistant", content: block.text, ...shared });
+        } else if (block.type === "thinking") {
+          if (typeof block.thinking !== "string") {
+            invalid(`Amp thinking block ${messageIndex}:${componentIndex} must contain thinking.`);
+          }
+          events.push({ type: "reasoning", content: block.thinking, ...shared });
+        } else {
+          const callId = nonemptyString(block.id);
+          if (!callId) {
+            invalid(`Amp tool use ${messageIndex}:${componentIndex} must contain an id.`);
+          }
+          const name = nonemptyString(block.name);
+          toolCallIds.add(callId);
+          events.push({
+            type: "tool_call",
+            id: callId,
+            ...name ? { name } : {},
+            args: jsonString(block.input),
+            ...shared
+          });
+        }
+      }
+    }
+    for (const callId of toolCallIds) {
+      if (!terminalResultIds.has(callId) && !nonterminalResultIds.has(callId)) {
+        diagnostics.push({
+          code: "incomplete_transcript",
+          message: "Amp thread export contains a tool call without a result.",
+          count: 1
+        });
+      }
+    }
+    if (lastConversationalRole === "user") {
+      diagnostics.push({
+        code: "incomplete_transcript",
+        message: "Amp thread export ends with an unmatched user turn.",
+        count: 1
+      });
+    }
+    const initial = isObject(root.env) && isObject(root.env.initial) ? root.env.initial : undefined;
+    const cwd = nonemptyString(initial?.workingDirectory);
+    const gitBranch = singleTreeRef(initial?.trees);
+    const createdAt = parseTimestamp(root.created);
+    return {
+      events,
+      context: {
+        source: "amp",
+        sourceGroupId,
+        sourceSequencePrimary: true,
+        ...cwd ? { cwd } : {},
+        ...gitBranch ? { gitBranch } : {},
+        ...createdAt ? { createdAt } : {}
+      },
+      diagnostics
+    };
+  }
+};
+function parseExport(transcript) {
+  let parsed;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    invalid("Amp thread export must be one complete JSON object.");
+  }
+  if (!isObject(parsed))
+    invalid("Amp thread export must be a JSON object.");
+  return parsed;
+}
+function resultText(result) {
+  return typeof result === "string" ? result : jsonString(result);
+}
+function singleTreeRef(value) {
+  if (!Array.isArray(value) || value.length !== 1 || !isObject(value[0]))
+    return;
+  const repository = value[0].repository;
+  return isObject(repository) ? nonemptyString(repository.ref) : undefined;
+}
+function invalid(message) {
+  throw new NormalizationError("invalid_input", message);
+}
+
 // src/adapters/claude-code/index.ts
 var TRANSPORT_TYPES = new Set([
   "progress",
@@ -1005,7 +1232,7 @@ function toolResultContent(content, isError) {
 }
 
 // src/adapters/gemini-cli/index.ts
-var TERMINAL_TOOL_STATUSES = new Set(["cancelled", "error", "success"]);
+var TERMINAL_TOOL_STATUSES2 = new Set(["cancelled", "error", "success"]);
 var geminiCliAdapter = {
   source: "gemini-cli",
   decode(transcript) {
@@ -1088,7 +1315,7 @@ var geminiCliAdapter = {
         });
         const status = nonemptyString(rawCall.status);
         const outputs = toolOutputs(rawCall.result);
-        if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES.has(status))) {
+        if (outputs.length === 0 && (!status || !TERMINAL_TOOL_STATUSES2.has(status))) {
           continue;
         }
         emit({
@@ -3544,7 +3771,7 @@ async function listTrajectories(input) {
   return paginate(items, input.cursor, limit);
 }
 function isKnownNormalizationOnlySource(source) {
-  return source === "atif" || source === "copilot-cli" || source === "cursor" || source === "gemini-cli" || source === "opencode";
+  return source === "atif" || source === "amp" || source === "copilot-cli" || source === "cursor" || source === "gemini-cli" || source === "opencode";
 }
 function resolveLimit2(limit) {
   if (limit === undefined)
@@ -3594,6 +3821,7 @@ function invalidCursor() {
 // src/index.ts
 var ADAPTERS = {
   atif: atifAdapter,
+  amp: ampAdapter,
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   "copilot-cli": copilotCliAdapter,

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -25,6 +25,8 @@ except ModuleNotFoundError:
 FIXTURES = (
     ("atif", "atif/tool-calls", "input.json"),
     ("atif", "atif/cleanup", "input.json"),
+    ("amp", "amp/orb-thread-export", "input.json"),
+    ("amp", "amp/cleanup", "input.json"),
     ("claude-code", "claude-code/tool-call", "input.jsonl"),
     ("claude-code", "claude-code/cleanup", "input.jsonl"),
     ("codex", "codex/tool-calls", "input.jsonl"),

--- a/src/adapters/amp/README.md
+++ b/src/adapters/amp/README.md
@@ -13,12 +13,12 @@ the corresponding decoded events. Structured tool result status is authoritative
 JSON so native fields are not discarded. User send times, assistant block times, assistant usage
 times/model, initial cwd, and a single repository-tree ref are preserved when present.
 
-Amp has no session-end event. An incomplete assistant turn or block, non-terminal or missing tool
-result, or unmatched final user turn therefore produces `incomplete_transcript`; it is not promoted
-to a fabricated session terminal. Existing core diagnostics continue to own orphan/duplicate tool
-results, duplicate call IDs, bounds, and timestamp synthesis/interpolation. Measured `info` records
-are compaction/transport artifacts and are dropped with `noise_record_dropped` because the full
-export retains the original messages.
+Amp has no session-end event. An incomplete assistant turn or block, `running`/`pending` or missing
+tool result, or unmatched final user turn therefore produces `incomplete_transcript`; it is not
+promoted to a fabricated session terminal. Existing core diagnostics continue to own
+orphan/duplicate tool results, duplicate call IDs, bounds, and timestamp synthesis/interpolation.
+Measured `info` records containing summary blocks are compaction/transport artifacts and are dropped
+with `noise_record_dropped` because the full export retains the original messages.
 
 Malformed or truncated JSON, missing envelope/session identity, duplicate message identity, and
 unknown semantic roles or blocks fail with `invalid_input` so format drift cannot silently lose

--- a/src/adapters/amp/README.md
+++ b/src/adapters/amp/README.md
@@ -1,0 +1,26 @@
+# Amp adapter
+
+Pass the complete JSON object emitted by `amp threads export <thread>` as the transcript. This is an
+export-only adapter: it does not execute Amp, discover local state, read files, or fetch threads.
+The same envelope is used for sandbox/orb and local or web-controlled threads; executor metadata
+does not select a different parser.
+
+The root thread `id` is the source group. Message array position is source order,
+`protocolMessageID` is native record identity, and content array position is component order. User
+and assistant text, plaintext assistant thinking, assistant tool uses, and user tool results become
+the corresponding decoded events. Structured tool result status is authoritative: `done` maps to
+`ok: true`, while `error` and `cancelled` map to `ok: false`. Object-valued results are serialized as
+JSON so native fields are not discarded. User send times, assistant block times, assistant usage
+times/model, initial cwd, and a single repository-tree ref are preserved when present.
+
+Amp has no session-end event. An incomplete assistant turn or block, non-terminal or missing tool
+result, or unmatched final user turn therefore produces `incomplete_transcript`; it is not promoted
+to a fabricated session terminal. Existing core diagnostics continue to own orphan/duplicate tool
+results, duplicate call IDs, bounds, and timestamp synthesis/interpolation. Measured `info` records
+are compaction/transport artifacts and are dropped with `noise_record_dropped` because the full
+export retains the original messages.
+
+Malformed or truncated JSON, missing envelope/session identity, duplicate message identity, and
+unknown semantic roles or blocks fail with `invalid_input` so format drift cannot silently lose
+model-visible input. Parent-thread lineage is not decoded or inferred; an external hook payload must
+remain its authority.

--- a/src/adapters/amp/index.ts
+++ b/src/adapters/amp/index.ts
@@ -13,6 +13,7 @@ import {
 } from "../shared.js";
 
 const TERMINAL_TOOL_STATUSES = new Set(["done", "error", "cancelled"]);
+const NONTERMINAL_TOOL_STATUSES = new Set(["running", "pending"]);
 
 export const ampAdapter: SourceAdapter = {
   source: "amp",
@@ -29,9 +30,9 @@ export const ampAdapter: SourceAdapter = {
     const events: DecodedEvent[] = [];
     const messageIds = new Set<number>();
     const protocolMessageIds = new Set<string>();
-    const toolCallIds = new Set<string>();
-    const terminalResultIds = new Set<string>();
-    const nonterminalResultIds = new Set<string>();
+    const toolCallCounts = new Map<string, number>();
+    const terminalResultCounts = new Map<string, number>();
+    const nonterminalResultCounts = new Map<string, number>();
     let lastConversationalRole: "user" | "assistant" | undefined;
 
     for (let messageIndex = 0; messageIndex < root.messages.length; messageIndex += 1) {
@@ -62,6 +63,18 @@ export const ampAdapter: SourceAdapter = {
         invalid(`Amp message ${messageIndex} must contain a content array.`);
       }
       if (message.role === "info") {
+        for (let componentIndex = 0; componentIndex < message.content.length; componentIndex += 1) {
+          const block = message.content[componentIndex];
+          if (
+            !isObject(block) ||
+            block.type !== "summary" ||
+            !isObject(block.summary) ||
+            block.summary.type !== "message" ||
+            typeof block.summary.summary !== "string"
+          ) {
+            invalid(`Amp info block ${messageIndex}:${componentIndex} has an unsupported shape.`);
+          }
+        }
         diagnostics.push({
           code: "noise_record_dropped",
           message: `Dropped an Amp info record at message ${messageIndex}.`,
@@ -104,8 +117,8 @@ export const ampAdapter: SourceAdapter = {
           if (!callId || !isObject(block.run) || typeof block.run.status !== "string") {
             invalid(`Amp tool result ${messageIndex}:${componentIndex} is malformed.`);
           }
-          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
-            nonterminalResultIds.add(callId);
+          if (NONTERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            increment(nonterminalResultCounts, callId);
             diagnostics.push({
               code: "incomplete_transcript",
               message: `Amp tool result at message ${messageIndex} is not terminal.`,
@@ -113,7 +126,13 @@ export const ampAdapter: SourceAdapter = {
             });
             continue;
           }
-          terminalResultIds.add(callId);
+          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            invalid(`Amp tool result ${messageIndex}:${componentIndex} has an unsupported status.`);
+          }
+          if (!Object.hasOwn(block.run, "result")) {
+            invalid(`Amp terminal tool result ${messageIndex}:${componentIndex} must contain result.`);
+          }
+          increment(terminalResultCounts, callId);
           events.push({
             type: "tool_result",
             callId,
@@ -187,11 +206,14 @@ export const ampAdapter: SourceAdapter = {
             invalid(`Amp tool use ${messageIndex}:${componentIndex} must contain an id.`);
           }
           const name = nonemptyString(block.name);
-          toolCallIds.add(callId);
+          if (!name || !isObject(block.input)) {
+            invalid(`Amp tool use ${messageIndex}:${componentIndex} is malformed.`);
+          }
+          increment(toolCallCounts, callId);
           events.push({
             type: "tool_call",
             id: callId,
-            ...(name ? { name } : {}),
+            name,
             args: jsonString(block.input),
             ...shared,
           });
@@ -199,12 +221,14 @@ export const ampAdapter: SourceAdapter = {
       }
     }
 
-    for (const callId of toolCallIds) {
-      if (!terminalResultIds.has(callId) && !nonterminalResultIds.has(callId)) {
+    for (const [callId, callCount] of toolCallCounts) {
+      const resultCount =
+        (terminalResultCounts.get(callId) ?? 0) + (nonterminalResultCounts.get(callId) ?? 0);
+      if (callCount > resultCount) {
         diagnostics.push({
           code: "incomplete_transcript",
           message: "Amp thread export contains a tool call without a result.",
-          count: 1,
+          count: callCount - resultCount,
         });
       }
     }
@@ -248,7 +272,14 @@ function parseExport(transcript: string): Record<string, unknown> {
 }
 
 function resultText(result: unknown): string {
-  return typeof result === "string" ? result : jsonString(result);
+  if (typeof result === "string") return result;
+  const serialized = JSON.stringify(result);
+  if (serialized === undefined) invalid("Amp terminal tool result is not JSON-serializable.");
+  return serialized;
+}
+
+function increment(counts: Map<string, number>, id: string): void {
+  counts.set(id, (counts.get(id) ?? 0) + 1);
 }
 
 function singleTreeRef(value: unknown): string | undefined {

--- a/src/adapters/amp/index.ts
+++ b/src/adapters/amp/index.ts
@@ -1,0 +1,262 @@
+import type {
+  DecodedEvent,
+  DecodedSession,
+  SourceAdapter,
+} from "../../internal.js";
+import type { Diagnostic } from "../../types.js";
+import { NormalizationError } from "../../types.js";
+import {
+  isObject,
+  jsonString,
+  nonemptyString,
+  parseTimestamp,
+} from "../shared.js";
+
+const TERMINAL_TOOL_STATUSES = new Set(["done", "error", "cancelled"]);
+
+export const ampAdapter: SourceAdapter = {
+  source: "amp",
+
+  decode(transcript: string): DecodedSession {
+    const root = parseExport(transcript);
+    const sourceGroupId = nonemptyString(root.id);
+    if (!sourceGroupId) invalid("Amp thread export must contain a non-empty root id.");
+    if (!Array.isArray(root.messages)) {
+      invalid("Amp thread export must contain a messages array.");
+    }
+
+    const diagnostics: Diagnostic[] = [];
+    const events: DecodedEvent[] = [];
+    const messageIds = new Set<number>();
+    const protocolMessageIds = new Set<string>();
+    const toolCallIds = new Set<string>();
+    const terminalResultIds = new Set<string>();
+    const nonterminalResultIds = new Set<string>();
+    let lastConversationalRole: "user" | "assistant" | undefined;
+
+    for (let messageIndex = 0; messageIndex < root.messages.length; messageIndex += 1) {
+      const message = root.messages[messageIndex];
+      if (!isObject(message)) invalid(`Amp message ${messageIndex} must be an object.`);
+
+      const messageId = message.messageId;
+      if (!Number.isSafeInteger(messageId) || (messageId as number) < 0) {
+        invalid(`Amp message ${messageIndex} must have a non-negative integer messageId.`);
+      }
+      if (messageIds.has(messageId as number)) {
+        invalid(`Amp thread export contains duplicate messageId at message ${messageIndex}.`);
+      }
+      messageIds.add(messageId as number);
+
+      const sourceRecordId = nonemptyString(message.protocolMessageID);
+      if (!sourceRecordId) {
+        invalid(`Amp message ${messageIndex} must have a non-empty protocolMessageID.`);
+      }
+      if (protocolMessageIds.has(sourceRecordId)) {
+        invalid(
+          `Amp thread export contains duplicate protocolMessageID at message ${messageIndex}.`,
+        );
+      }
+      protocolMessageIds.add(sourceRecordId);
+
+      if (!Array.isArray(message.content)) {
+        invalid(`Amp message ${messageIndex} must contain a content array.`);
+      }
+      if (message.role === "info") {
+        diagnostics.push({
+          code: "noise_record_dropped",
+          message: `Dropped an Amp info record at message ${messageIndex}.`,
+          count: 1,
+        });
+        continue;
+      }
+      if (message.role !== "user" && message.role !== "assistant") {
+        invalid(`Amp message ${messageIndex} has an unsupported semantic role.`);
+      }
+      lastConversationalRole = message.role;
+
+      if (message.role === "user") {
+        const timestamp = parseTimestamp(isObject(message.meta) ? message.meta.sentAt : undefined);
+        for (let componentIndex = 0; componentIndex < message.content.length; componentIndex += 1) {
+          const block = message.content[componentIndex];
+          if (!isObject(block)) {
+            invalid(`Amp user block ${messageIndex}:${componentIndex} must be an object.`);
+          }
+          if (block.type === "text") {
+            if (typeof block.text !== "string") {
+              invalid(`Amp text block ${messageIndex}:${componentIndex} must contain text.`);
+            }
+            events.push({
+              type: "message",
+              role: "user",
+              content: block.text,
+              ...(timestamp ? { timestamp } : {}),
+              sourceRecordId,
+              sourceSequence: messageIndex,
+              componentIndex,
+            });
+            continue;
+          }
+          if (block.type !== "tool_result") {
+            invalid(`Amp user block ${messageIndex}:${componentIndex} has an unsupported type.`);
+          }
+
+          const callId = nonemptyString(block.toolUseID);
+          if (!callId || !isObject(block.run) || typeof block.run.status !== "string") {
+            invalid(`Amp tool result ${messageIndex}:${componentIndex} is malformed.`);
+          }
+          if (!TERMINAL_TOOL_STATUSES.has(block.run.status)) {
+            nonterminalResultIds.add(callId);
+            diagnostics.push({
+              code: "incomplete_transcript",
+              message: `Amp tool result at message ${messageIndex} is not terminal.`,
+              count: 1,
+            });
+            continue;
+          }
+          terminalResultIds.add(callId);
+          events.push({
+            type: "tool_result",
+            callId,
+            content: resultText(block.run.result),
+            ok: block.run.status === "done",
+            ...(timestamp ? { timestamp } : {}),
+            sourceRecordId,
+            sourceSequence: messageIndex,
+            componentIndex,
+          });
+        }
+        continue;
+      }
+
+      const messageComplete =
+        isObject(message.state) && message.state.type === "complete";
+      if (!messageComplete) {
+        diagnostics.push({
+          code: "incomplete_transcript",
+          message: `Amp assistant turn at message ${messageIndex} is not complete.`,
+          count: 1,
+        });
+      }
+      const fallbackTimestamp = parseTimestamp(
+        isObject(message.usage) ? message.usage.timestamp : undefined,
+      );
+      const model = nonemptyString(isObject(message.usage) ? message.usage.model : undefined);
+
+      for (let componentIndex = 0; componentIndex < message.content.length; componentIndex += 1) {
+        const block = message.content[componentIndex];
+        if (!isObject(block)) {
+          invalid(`Amp assistant block ${messageIndex}:${componentIndex} must be an object.`);
+        }
+        if (block.type !== "text" && block.type !== "thinking" && block.type !== "tool_use") {
+          invalid(`Amp assistant block ${messageIndex}:${componentIndex} has an unsupported type.`);
+        }
+        const blockComplete =
+          block.blockState === "complete" &&
+          (block.type !== "tool_use" || block.complete === true);
+        if (!blockComplete) {
+          diagnostics.push({
+            code: "incomplete_transcript",
+            message: `Amp assistant block ${messageIndex}:${componentIndex} is not complete.`,
+            count: 1,
+          });
+          continue;
+        }
+
+        const timestamp =
+          parseTimestamp(block.startTime) ?? parseTimestamp(block.finalTime) ?? fallbackTimestamp;
+        const shared = {
+          ...(timestamp ? { timestamp } : {}),
+          ...(model ? { model } : {}),
+          sourceRecordId,
+          sourceSequence: messageIndex,
+          componentIndex,
+        };
+        if (block.type === "text") {
+          if (typeof block.text !== "string") {
+            invalid(`Amp text block ${messageIndex}:${componentIndex} must contain text.`);
+          }
+          events.push({ type: "message", role: "assistant", content: block.text, ...shared });
+        } else if (block.type === "thinking") {
+          if (typeof block.thinking !== "string") {
+            invalid(`Amp thinking block ${messageIndex}:${componentIndex} must contain thinking.`);
+          }
+          events.push({ type: "reasoning", content: block.thinking, ...shared });
+        } else {
+          const callId = nonemptyString(block.id);
+          if (!callId) {
+            invalid(`Amp tool use ${messageIndex}:${componentIndex} must contain an id.`);
+          }
+          const name = nonemptyString(block.name);
+          toolCallIds.add(callId);
+          events.push({
+            type: "tool_call",
+            id: callId,
+            ...(name ? { name } : {}),
+            args: jsonString(block.input),
+            ...shared,
+          });
+        }
+      }
+    }
+
+    for (const callId of toolCallIds) {
+      if (!terminalResultIds.has(callId) && !nonterminalResultIds.has(callId)) {
+        diagnostics.push({
+          code: "incomplete_transcript",
+          message: "Amp thread export contains a tool call without a result.",
+          count: 1,
+        });
+      }
+    }
+    if (lastConversationalRole === "user") {
+      diagnostics.push({
+        code: "incomplete_transcript",
+        message: "Amp thread export ends with an unmatched user turn.",
+        count: 1,
+      });
+    }
+
+    const initial = isObject(root.env) && isObject(root.env.initial) ? root.env.initial : undefined;
+    const cwd = nonemptyString(initial?.workingDirectory);
+    const gitBranch = singleTreeRef(initial?.trees);
+    const createdAt = parseTimestamp(root.created);
+
+    return {
+      events,
+      context: {
+        source: "amp",
+        sourceGroupId,
+        sourceSequencePrimary: true,
+        ...(cwd ? { cwd } : {}),
+        ...(gitBranch ? { gitBranch } : {}),
+        ...(createdAt ? { createdAt } : {}),
+      },
+      diagnostics,
+    };
+  },
+};
+
+function parseExport(transcript: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(transcript);
+  } catch {
+    invalid("Amp thread export must be one complete JSON object.");
+  }
+  if (!isObject(parsed)) invalid("Amp thread export must be a JSON object.");
+  return parsed;
+}
+
+function resultText(result: unknown): string {
+  return typeof result === "string" ? result : jsonString(result);
+}
+
+function singleTreeRef(value: unknown): string | undefined {
+  if (!Array.isArray(value) || value.length !== 1 || !isObject(value[0])) return undefined;
+  const repository = value[0].repository;
+  return isObject(repository) ? nonemptyString(repository.ref) : undefined;
+}
+
+function invalid(message: string): never {
+  throw new NormalizationError("invalid_input", message);
+}

--- a/src/canonical.ts
+++ b/src/canonical.ts
@@ -84,6 +84,7 @@ export function buildCanonicalRecords(
         sourceTimestamp,
         basis,
         identity.stableSourceRecordId,
+        internal.context.sourceSequencePrimary ?? false,
       ),
       component_index: componentIndex,
       record_type: type,
@@ -158,12 +159,17 @@ function buildOrderId(
   sourceTimestamp: string | null,
   basis: CanonicalSourceBasis | null,
   stableSourceRecordId: string,
+  sourceSequencePrimary: boolean,
 ): string {
   const rank = type === "meta" ? "0" : "1";
   // Never derive order from record_timestamp: it can be synthesized from array
   // position and would make source_order_id depend on transport-arrival order.
   const timestamp =
-    type === "meta" ? META_ORDER_TIMESTAMP : (sourceTimestamp ?? MISSING_TIME_SENTINEL);
+    type === "meta"
+      ? META_ORDER_TIMESTAMP
+      : sourceSequencePrimary
+        ? MISSING_TIME_SENTINEL
+        : (sourceTimestamp ?? MISSING_TIME_SENTINEL);
   const sequence =
     basis?.sourceSequence !== undefined
       ? String(basis.sourceSequence).padStart(SEQUENCE_WIDTH, "0")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { atifAdapter } from "./adapters/atif/index.js";
+import { ampAdapter } from "./adapters/amp/index.js";
 import { claudeCodeAdapter } from "./adapters/claude-code/index.js";
 import { codexAdapter } from "./adapters/codex/index.js";
 import { copilotCliAdapter } from "./adapters/copilot-cli/index.js";
@@ -32,6 +33,7 @@ import { NormalizationError } from "./types.js";
 
 const ADAPTERS: Record<TranscriptTrajectorySource, SourceAdapter> = {
   atif: atifAdapter,
+  amp: ampAdapter,
   "claude-code": claudeCodeAdapter,
   codex: codexAdapter,
   "copilot-cli": copilotCliAdapter,

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -92,6 +92,12 @@ export interface SessionContext {
    */
   sourceGroupId?: string;
   /**
+   * The source's sequence is the authoritative order and its timestamps are
+   * descriptive or sparse. Canonical order uses sequence ahead of timestamp
+   * without discarding any observed source timestamps.
+   */
+  sourceSequencePrimary?: boolean;
+  /**
    * The input contains more than one plausible source group. Canonical callers
    * must provide the authoritative group instead of using a sentinel.
    */

--- a/src/listing.ts
+++ b/src/listing.ts
@@ -112,6 +112,7 @@ export async function listTrajectories(
 function isKnownNormalizationOnlySource(source: AnyTrajectorySource): boolean {
   return (
     source === "atif" ||
+    source === "amp" ||
     source === "copilot-cli" ||
     source === "cursor" ||
     source === "gemini-cli" ||

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { ResolvedNormalizationFilters } from "./filters.js";
 
 export type TrajectorySource =
   | "atif"
+  | "amp"
   | "claude-code"
   | "codex"
   | "copilot-cli"
@@ -96,6 +97,7 @@ export interface NormalizeInput {
 export type DiagnosticCode =
   | "invalid_json_line"
   | "non_object_json_line"
+  | "incomplete_transcript"
   | "injected_context_dropped"
   | "noise_record_dropped"
   | "sidechain_record_dropped"

--- a/test/canonical.test.ts
+++ b/test/canonical.test.ts
@@ -26,6 +26,7 @@ const validateCanonical = new Ajv2020().compile(canonicalSchema);
 const HEX_64 = /^[0-9a-f]{64}$/;
 
 const goldenFixtures = [
+  { source: "amp", name: "amp/orb-thread-export", golden: "amp__orb-thread-export" },
   { source: "claude-code", name: "claude-code/tool-call", golden: "claude-code__tool-call" },
   { source: "codex", name: "codex/tool-calls", golden: "codex__tool-calls" },
   { source: "hermes", name: "hermes/tool-calls", golden: "hermes__tool-calls" },
@@ -55,7 +56,9 @@ describe("canonical golden fixtures", () => {
   for (const fixture of goldenFixtures) {
     test(fixture.name, () => {
       const inputFile =
-        fixture.source === "openhands" || fixture.source === "hermes"
+        fixture.source === "amp" ||
+        fixture.source === "openhands" ||
+        fixture.source === "hermes"
           ? "input.json"
           : "input.jsonl";
       const transcript = fixtureText(fixture.name, inputFile);
@@ -81,6 +84,7 @@ describe("canonical invariants", () => {
     test(fixture.name, () => {
       const inputFile =
         fixture.source === "atif" ||
+        fixture.source === "amp" ||
         fixture.source === "openhands" ||
         fixture.source === "hermes" ||
         fixture.source === "gemini-cli" ||

--- a/test/listing.test.ts
+++ b/test/listing.test.ts
@@ -129,6 +129,7 @@ describe("listTrajectories", () => {
   test("reports normalization-only sources without pretending to discover a store", async () => {
     for (const source of [
       "atif",
+      "amp",
       "copilot-cli",
       "cursor",
       "gemini-cli",

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -13,6 +13,8 @@ import type { NormalizeResult, TrajectorySource } from "../src/index.js";
 const fixtures = [
   { source: "atif", name: "atif/tool-calls" },
   { source: "atif", name: "atif/cleanup" },
+  { source: "amp", name: "amp/orb-thread-export" },
+  { source: "amp", name: "amp/cleanup" },
   { source: "claude-code", name: "claude-code/tool-call" },
   { source: "claude-code", name: "claude-code/cleanup" },
   { source: "claude-code", name: "claude-code/subagent" },
@@ -59,6 +61,7 @@ describe("golden fixtures", () => {
       const input = fixtureText(
         fixture.name,
         fixture.source === "atif" ||
+          fixture.source === "amp" ||
           fixture.source === "openhands" ||
           fixture.source === "hermes" ||
           fixture.source === "gemini-cli" ||
@@ -402,6 +405,105 @@ describe("public API", () => {
       }),
     ]) {
       expect(() => normalizeTranscript({ source: "atif", transcript })).toThrow(
+        expect.objectContaining({ code: "invalid_input" }),
+      );
+    }
+  });
+
+  test("normalizes a complete Amp orb export without incompleteness", () => {
+    const result = normalizeTranscript({
+      source: "amp",
+      transcript: fixtureText("amp/orb-thread-export", "input.json"),
+    });
+
+    expect(result.records).toEqual(
+      expect.arrayContaining([
+        { role: "meta", source: "amp", cwd: "/workspace/example", git_branch: "main", model: "example/model" },
+        expect.objectContaining({
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            { id: "tool-1", name: "shell_command", args: '{"command":"pwd"}' },
+          ],
+        }),
+        expect.objectContaining({
+          role: "tool",
+          tool_call_id: "tool-1",
+          content: '{"output":"/workspace/example","exitCode":0}',
+          ok: true,
+        }),
+      ]),
+    );
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).not.toContain(
+      "incomplete_transcript",
+    );
+  });
+
+  test("reports incomplete Amp orb exports without inventing session terminality", () => {
+    const exportDocument = JSON.parse(
+      fixtureText("amp/orb-thread-export", "input.json"),
+    );
+    exportDocument.messages.pop();
+
+    const result = normalizeTranscript({
+      source: "amp",
+      transcript: JSON.stringify(exportDocument),
+    });
+
+    expect(result.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "incomplete_transcript",
+        message: "Amp thread export ends with an unmatched user turn.",
+      }),
+    );
+  });
+
+  test("reports non-terminal and missing Amp tool results", () => {
+    for (const status of ["running", undefined]) {
+      const exportDocument = JSON.parse(
+        fixtureText("amp/orb-thread-export", "input.json"),
+      );
+      if (status) {
+        exportDocument.messages[2].content[0].run.status = status;
+      } else {
+        exportDocument.messages.splice(2, 1);
+      }
+
+      const result = normalizeTranscript({
+        source: "amp",
+        transcript: JSON.stringify(exportDocument),
+      });
+
+      expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+        "incomplete_transcript",
+      );
+      expect(result.records.some((record) => record.role === "tool")).toBe(false);
+    }
+  });
+
+  test("rejects structurally ambiguous Amp exports", () => {
+    const valid = JSON.parse(fixtureText("amp/orb-thread-export", "input.json"));
+    const duplicateMessageId = structuredClone(valid);
+    duplicateMessageId.messages[1].messageId = duplicateMessageId.messages[0].messageId;
+    const duplicateProtocolId = structuredClone(valid);
+    duplicateProtocolId.messages[1].protocolMessageID =
+      duplicateProtocolId.messages[0].protocolMessageID;
+    const unknownRole = structuredClone(valid);
+    unknownRole.messages[0].role = "system";
+    const unknownBlock = structuredClone(valid);
+    unknownBlock.messages[1].content[0].type = "stream_delta";
+
+    for (const transcript of [
+      "{",
+      "[]",
+      "{}",
+      JSON.stringify({ id: "T-missing-messages" }),
+      JSON.stringify(duplicateMessageId),
+      JSON.stringify(duplicateProtocolId),
+      JSON.stringify(unknownRole),
+      JSON.stringify(unknownBlock),
+    ]) {
+      expect(() => normalizeTranscript({ source: "amp", transcript })).toThrow(
         expect.objectContaining({ code: "invalid_input" }),
       );
     }

--- a/test/normalize.test.ts
+++ b/test/normalize.test.ts
@@ -459,7 +459,7 @@ describe("public API", () => {
   });
 
   test("reports non-terminal and missing Amp tool results", () => {
-    for (const status of ["running", undefined]) {
+    for (const status of ["running", "pending", undefined]) {
       const exportDocument = JSON.parse(
         fixtureText("amp/orb-thread-export", "input.json"),
       );
@@ -492,6 +492,16 @@ describe("public API", () => {
     unknownRole.messages[0].role = "system";
     const unknownBlock = structuredClone(valid);
     unknownBlock.messages[1].content[0].type = "stream_delta";
+    const unknownInfoBlock = structuredClone(valid);
+    unknownInfoBlock.messages[3].content[0].type = "replacement_summary";
+    const unknownResultStatus = structuredClone(valid);
+    unknownResultStatus.messages[2].content[0].run.status = "success";
+    const missingToolName = structuredClone(valid);
+    delete missingToolName.messages[1].content[1].name;
+    const missingToolInput = structuredClone(valid);
+    delete missingToolInput.messages[1].content[1].input;
+    const missingToolResult = structuredClone(valid);
+    delete missingToolResult.messages[2].content[0].run.result;
 
     for (const transcript of [
       "{",
@@ -502,11 +512,39 @@ describe("public API", () => {
       JSON.stringify(duplicateProtocolId),
       JSON.stringify(unknownRole),
       JSON.stringify(unknownBlock),
+      JSON.stringify(unknownInfoBlock),
+      JSON.stringify(unknownResultStatus),
+      JSON.stringify(missingToolName),
+      JSON.stringify(missingToolInput),
+      JSON.stringify(missingToolResult),
     ]) {
       expect(() => normalizeTranscript({ source: "amp", transcript })).toThrow(
         expect.objectContaining({ code: "invalid_input" }),
       );
     }
+  });
+
+  test("reports every duplicate-ID Amp tool call without a result", () => {
+    const exportDocument = JSON.parse(
+      fixtureText("amp/orb-thread-export", "input.json"),
+    );
+    exportDocument.messages[1].content.push(
+      structuredClone(exportDocument.messages[1].content[1]),
+    );
+
+    const result = normalizeTranscript({
+      source: "amp",
+      transcript: JSON.stringify(exportDocument),
+    });
+
+    expect(result.diagnostics).toContainEqual({
+      code: "incomplete_transcript",
+      message: "Amp thread export contains a tool call without a result.",
+      count: 1,
+    });
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      "duplicate_tool_call_id",
+    );
   });
 
   test("accepts every published ATIF v1 schema version", () => {


### PR DESCRIPTION
## Summary

- add an export-only `amp` adapter for complete JSON documents produced by `amp threads export <thread>`
- preserve native thread/message/tool identity, array ordering, structured tool-result status, reasoning, timestamps, model, cwd, and single-tree refs
- report incomplete turns, blocks, results, and unmatched user tails without inventing a session-end event
- add TypeScript/Python source parity, sanitized orb fixtures, canonical goldens, adverse tests, listing behavior, and adapter documentation

## Design

The adapter is pure: it does not execute Amp, discover local state, read files, or access the network. Orb/sandbox and local/web-controlled exports use the same decoder because executor metadata does not alter transcript semantics.

Message array sequence is authoritative for Amp ordering. Observed timestamps remain preserved but do not reorder sparse tool-result records. Parent-thread lineage remains outside this transcript adapter.

The implementation was checked against aggregate structure from complete and in-progress exports produced by Amp `0.0.1787378726-g9570e9`, including `executorType: "sandbox"`; no private transcript content or identifiers are included.

## Verification

- `bun run check` — 187 passed, 7 optional Deep Agents tests skipped, 0 failed; typecheck and build passed
- `PYTHONPATH=python/src python3 -m unittest discover -s python/tests -v` — 12 passed, 1 optional LangGraph SQLite test skipped
- built-package Node import matched the canonical Amp golden
- `npm pack --dry-run` included the Amp adapter artifacts
- changed-file credential scan and proposed-diff whitespace check passed
- post-review adverse tests cover missing tool fields/results, unknown statuses/info shapes, and duplicate-ID calls with unmatched results

